### PR TITLE
Log messages

### DIFF
--- a/Makefile.linux_gfortran-local
+++ b/Makefile.linux_gfortran-local
@@ -49,7 +49,7 @@ EXECUTABLE=KPP_ocean
 
 FORCED_FILES = $(wildcard *.F90)
 FORCED_OBJS = $(FORCED_FILES:.F90=.o)
-FORCED_MODS = mckpp_parameters.mod mckpp_timer.mod mckpp_data_fields.mod mckpp_namelists.mod mckpp_xios_control.mod mckpp_xios_io.mod
+FORCED_MODS = mckpp_log_messages.mod mckpp_parameters.mod mckpp_timer.mod mckpp_data_fields.mod mckpp_namelists.mod mckpp_xios_control.mod mckpp_xios_io.mod
 
 FORCED_COMPILE = $(F90) $(F90_FLAGS) $(CPP_FLAGS) $(F90_CPP_FLAG)-DARCHER $(OASIS3_MOD_FLAG) $(XIOS_INC) $(NCDF_INC) 
 FORCED_LINK = $(F90)  $(F90_FLAGS) $(LINK_FLAGS) $(FORCED_OBJS) -o ${EXECUTABLE} ${XIOS_LIB} ${NCDF_LIB}
@@ -58,6 +58,9 @@ FORCED_LINK = $(F90)  $(F90_FLAGS) $(LINK_FLAGS) $(FORCED_OBJS) -o ${EXECUTABLE}
 .SUFFIXES: .F90 .o
 
 .F90.o : $(FORCED_MODS)
+	$(FORCED_COMPILE) -c $<
+
+mckpp_log_messages.mod : mc-kpp_log_messages.F90
 	$(FORCED_COMPILE) -c $<
 
 mckpp_parameters.mod : mc-kpp_parameters.F90

--- a/mc-kpp_abort.F90
+++ b/mc-kpp_abort.F90
@@ -1,6 +1,4 @@
 SUBROUTINE MCKPP_ABORT()
-
-  USE mckpp_parameters, ONLY: nuout, nuerr
   
   IMPLICIT NONE
   

--- a/mc-kpp_boundary_interpolate.F90
+++ b/mc-kpp_boundary_interpolate.F90
@@ -12,12 +12,15 @@ SUBROUTINE MCKPP_BOUNDARY_INTERPOLATE_TEMP()
 #else
   USE mckpp_data_fields, ONLY: kpp_3d_fields, kpp_const_fields
 #endif
+  USE mckpp_log_messages, ONLY: mckpp_print, max_message_len
   USE mckpp_parameters, ONLY: npts, nzp1
 
   IMPLICIT NONE
 
   INTEGER prev_time,next_time,true_time
   REAL prev_weight,next_weight,ndays_upd_ocnT
+  CHARACTER(LEN=31) :: routine = "MCKPP_BOUNDARY_INTERPOLATE_TEMP"
+  CHARACTER(LEN=max_message_len) :: message
 
 #ifdef MCKPP_CAM3
   INTEGER :: icol,ncol,ichnk
@@ -40,10 +43,15 @@ SUBROUTINE MCKPP_BOUNDARY_INTERPOLATE_TEMP()
      prev_time=prev_time+kpp_const_fields%ocnT_period
   ELSE
      prev_weight=(ndays_upd_ocnT-(true_time-prev_time))/ndays_upd_ocnT
-  ENDIF
-  WRITE(6,*) 'interp_ocnT : true_time = ',true_time
-  WRITE(6,*) 'interp_ocnT : prev_time = ',prev_time
-  WRITE(6,*) 'interp_ocnT : prev_weight = ',prev_weight
+   ENDIF
+
+  WRITE(message,*) "true_time = ", true_time
+  CALL mckpp_print(routine, message)
+  WRITE(message,*) "prev_time = ", prev_time
+  CALL mckpp_print(routine, message)
+  WRITE(message,*) "prev_weight = ", prev_weight
+  CALL mckpp_print(routine, message)
+  
   kpp_const_fields%time=prev_time
   CALL MCKPP_READ_TEMPERATURES_3D()
 #ifdef MCKPP_CAM3 
@@ -58,8 +66,12 @@ SUBROUTINE MCKPP_BOUNDARY_INTERPOLATE_TEMP()
   ! Read ocean temperatures for next time
   next_time=prev_time+ndays_upd_ocnT
   next_weight=1-prev_weight
-  WRITE(6,*) 'interp_ocnT : next_time = ',next_time
-  WRITE(6,*) 'interp_ocnT : next_weight = ',next_weight
+
+  WRITE(message,*) "next_time = ", next_time
+  CALL mckpp_print(routine, message)
+  WRITE(message,*) "next_weight = ", next_weight
+  CALL mckpp_print(routine, message)
+
   kpp_const_fields%time=next_time
   CALL MCKPP_READ_TEMPERATURES_3D()
 #ifdef MCKPP_CAM3 
@@ -81,7 +93,7 @@ SUBROUTINE MCKPP_BOUNDARY_INTERPOLATE_TEMP()
 END SUBROUTINE MCKPP_BOUNDARY_INTERPOLATE_TEMP
 
 
-SUBROUTINE MCKPP_BOUNDARY_INTERPOLATE_SAL
+SUBROUTINE MCKPP_BOUNDARY_INTERPOLATE_SAL()
   
 #ifdef MCKPP_CAM3
   USE mckpp_types, only: kpp_3d_fields,kpp_const_fields
@@ -90,12 +102,15 @@ SUBROUTINE MCKPP_BOUNDARY_INTERPOLATE_SAL
 #else
   USE mckpp_data_fields, ONLY: kpp_3d_fields, kpp_const_fields
 #endif
+  USE mckpp_log_messages, ONLY: mckpp_print, max_message_len
   USE mckpp_parameters, ONLY: npts, nzp1
 
   IMPLICIT NONE
 
   INTEGER prev_time,next_time,true_time
   REAL prev_weight,next_weight,ndays_upd_sal
+  CHARACTER(LEN=31) :: routine = "mckpp_boundary_interpolate_temp"
+  CHARACTER(LEN=max_message_len) :: message
 
 #ifdef MCKPP_CAM3
   INTEGER :: icol,ncol,ichnk
@@ -119,9 +134,14 @@ SUBROUTINE MCKPP_BOUNDARY_INTERPOLATE_SAL
   ELSE
      prev_weight=(ndays_upd_sal-(true_time-prev_time))/ndays_upd_sal
   ENDIF
-  WRITE(6,*) 'interp_sal : true_time = ',true_time
-  WRITE(6,*) 'interp_sal : prev_time = ',prev_time
-  WRITE(6,*) 'interp_sal : prev_weight = ',prev_weight
+
+  WRITE(message,*) "true_time = ", true_time
+  CALL mckpp_print(routine, message)
+  WRITE(message,*) "prev_time = ", prev_time
+  CALL mckpp_print(routine, message)
+  WRITE(message,*) "prev_weight = ", prev_weight
+  CALL mckpp_print(routine, message)
+  
   kpp_const_fields%time=prev_time
   CALL MCKPP_READ_SALINITY_3D()
 #ifdef MCKPP_CAM3 
@@ -136,8 +156,12 @@ SUBROUTINE MCKPP_BOUNDARY_INTERPOLATE_SAL
   ! Read ocean salinity for next time
   next_time=prev_time+ndays_upd_sal
   next_weight=1-prev_weight
-  WRITE(6,*) 'interp_sal : next_time = ',next_time
-  WRITE(6,*) 'interp_sal : next_weight = ',next_weight
+
+  WRITE(message,*) "next_time = ", next_time
+  CALL mckpp_print(routine, message)
+  WRITE(message,*) "next_weight = ", next_weight
+  CALL mckpp_print(routine, message)
+
   kpp_const_fields%time=next_time
   CALL MCKPP_READ_SALINITY_3D()
 #ifdef MCKPP_CAM3 

--- a/mc-kpp_boundary_update.F90
+++ b/mc-kpp_boundary_update.F90
@@ -47,7 +47,8 @@ SUBROUTINE MCKPP_BOUNDARY_UPDATE()
   ! Update surface currents - this routine does not exist 
   ! IF(kpp_const_fields%L_UPD_CLIMCURR .AND. MOD(kpp_const_fields%ntime-1,kpp_const_fields%ndtupdcurr) .EQ. 0) THEN
      ! CALL read_surface_currents(kpp_3d_fields,kpp_const_fields)
-     ! CALL mckpp_print(routine, "Called read_surface_currents, ntime = ", kpp_const_fields%ntime
+     ! WRITE(message,*) "Called read_surface_currents, ntime = ", kpp_const_fields%ntime
+     ! CALL mckpp_print(routine, message) 
   ! ENDIF
   
   ! Update heat corrections

--- a/mc-kpp_boundary_update.F90
+++ b/mc-kpp_boundary_update.F90
@@ -5,53 +5,61 @@ SUBROUTINE MCKPP_BOUNDARY_UPDATE()
 #else
   USE mckpp_data_fields, ONLY: kpp_const_fields
 #endif
-  USE mckpp_parameters, ONLY: nuout
+  USE mckpp_log_messages, ONLY: mckpp_print, max_message_len
 
   ! Update all boundary conditions that are read from netCDF files,
   ! except for surface fluxes, which are handled in MCKPP_UPDATE_FLUXES or coupling routines.
 
   IMPLICIT NONE
+  
+  CHARACTER(LEN=21) :: routine = "MCKPP_BOUNDARY_UPDATE"
+  CHARACTER(LEN=max_message_len) :: message
 
   ! Update SST
   IF (kpp_const_fields%L_UPD_CLIMSST .AND. &
-       MOD(kpp_const_fields%ntime-1,kpp_const_fields%ndtupdsst) .EQ. 0) THEN
-     !WRITE(6,*) 'MCKPP_BOUNDARY_UPDATE: Calling MCKPP_READ_SST'
+      MOD(kpp_const_fields%ntime-1,kpp_const_fields%ndtupdsst) .EQ. 0) THEN
+     ! CALL mckpp_print(routine, "Calling MCKPP_READ_SST") 
      CALL MCKPP_READ_SST()
-     !WRITE(6,*) 'MCKPP_BOUNDARY_UPDATE: Returned from MCKPP_READ_SST'
-     !WRITE(nuout,*) 'KPP: Called read_sstin, ntime =',kpp_const_fields%ntime
+     ! CALL mckpp_print(routine, "Returned from MCKPP_READ_SST")
+     ! WRITE(message,*) "Called read_sstin, ntime = ", kpp_const_fields%ntime
+     ! CALL mckpp_print(routine, message)
 
      ! SST0 specifies the temperature to which to relax the mixed-layer temperature.
      ! The use of the relaxation is controlled by L_RELAX_SST.
      ! Changing L_RELAX_SST .OR. L_COUPLE to just L_RELAX_SST - NPK 2/11/09 - R3
      IF (kpp_const_fields%L_RELAX_SST) THEN
-        !WRITE(6,*) 'MCKPP_BOUNDARY_UPDATE: Calling MCKPP_PHYSICS_OVERRIDES_SST0'
+        ! CALL mckpp_print(routine, "Calling MCKPP_PHYSICS_OVERRIDES_SST0")
         CALL MCKPP_PHYSICS_OVERRIDES_SST0()
-        !WRITE(nuout,*) 'KPP: Called upd_sst0, ntime =',kpp_const_fields%ntime               
+        ! WRITE(message,*) "Called upd_sst0, ntime = ", kpp_const_fields%ntime
+        ! CALL mckpp_print(routine, message)
      ENDIF
   ENDIF
   
   ! Update sea ice  
   IF (kpp_const_fields%L_UPD_CLIMICE .AND. MOD(kpp_const_fields%ntime-1,kpp_const_fields%ndtupdice) .EQ. 0) THEN
-     !WRITE(6,*) 'MCKPP_BOUNDARY_UPDATE: Calling MCKPP_READ_ICE'
+     ! CALL mckpp_print(routine, "Calling MCKPP_READ_ICE")
      CALL MCKPP_READ_ICE()
-     !WRITE(6,*) 'MCKPP_BOUNDARY_UPDATE: Returned from MCKPP_READ_ICE'
-     !WRITE(nuout,*) 'KPP: Called read_icein, ntime =',kpp_const_fields%ntime
+     ! CALL mckpp_print(routine, "Returned from MCKPP_READ_ICE"
+     ! WRITE(message,*) "Called read_icein, ntime = ", kpp_const_fields%ntime
+     ! CALL mckpp_print(routine, message)
   ENDIF
   
-  ! Update surface currents
-  !IF(kpp_const_fields%L_UPD_CLIMCURR .AND. MOD(kpp_const_fields%ntime-1,kpp_const_fields%ndtupdcurr) .EQ. 0) THEN
-     !CALL read_surface_currents(kpp_3d_fields,kpp_const_fields)
-     !WRITE(nuout,*) 'KPP: Called read_surface_currents, ntime =',kpp_const_fields%ntime
-  !ENDIF
+  ! Update surface currents - this routine does not exist 
+  ! IF(kpp_const_fields%L_UPD_CLIMCURR .AND. MOD(kpp_const_fields%ntime-1,kpp_const_fields%ndtupdcurr) .EQ. 0) THEN
+     ! CALL read_surface_currents(kpp_3d_fields,kpp_const_fields)
+     ! CALL mckpp_print(routine, "Called read_surface_currents, ntime = ", kpp_const_fields%ntime
+  ! ENDIF
   
   ! Update heat corrections
   IF (kpp_const_fields%L_UPD_FCORR .AND. MOD(kpp_const_fields%ntime-1,kpp_const_fields%ndtupdfcorr) .EQ. 0) THEN
      IF (kpp_const_fields%L_FCORR_WITHZ) THEN
         CALL MCKPP_READ_FCORR_3D()
-        !WRITE(nuout,*) 'KPP: Called read_fcorrwithz, ntime =',kpp_const_fields%ntime
+        ! WRITE(messsage,*) "Called read_fcorrwithz, ntime = ", kpp_const_fields%ntime
+        ! CALL mckpp_print(routine, message)
      ELSEIF (kpp_const_fields%L_FCORR) THEN
         CALL MCKPP_READ_FCORR_2D()
-        !WRITE(nuout,*) 'KPP: Called read_fcorr, ntime =',kpp_const_fields%ntime
+        ! WRITE(messsage,*) "Called read_fcorr, ntime = ", kpp_const_fields%ntime
+        ! CALL mckpp_print(routine, message)
      ENDIF
   ENDIF
 
@@ -59,39 +67,46 @@ SUBROUTINE MCKPP_BOUNDARY_UPDATE()
   IF (kpp_const_fields%L_UPD_SFCORR .AND. MOD(kpp_const_fields%ntime-1,kpp_const_fields%ndtupdsfcorr) .EQ. 0) THEN
      IF (kpp_const_fields%L_SFCORR_WITHZ) THEN
         CALL MCKPP_READ_SFCORR_3D()
-        !WRITE(nuout,*) 'KPP: Called read_sfcorrwithz, ntime =',kpp_const_fields%ntime
+        ! WRITE(messsage,*) "Called read_sfcorrwithz, ntime = ", kpp_const_fields%ntime
+        ! CALL mckpp_print(routine, message)
      ELSEIF (kpp_const_fields%L_SFCORR) THEN
         CALL MCKPP_READ_SFCORR_2D()
-        !WRITE(nuout,*) 'KPP: Called read_sfcorr, ntime =',kpp_const_fields%ntime
+        ! WRITE(messsage,*) "Called read_sfcorr, ntime = ", kpp_const_fields%ntime
+        ! CALL mckpp_print(routine, message)
      ENDIF
   ENDIF
   
   ! Update bottom temperatures
   IF (kpp_const_fields%L_UPD_BOTTOM_TEMP .AND. MOD(kpp_const_fields%ntime-1,kpp_const_fields%ndtupdbottom) .EQ. 0) THEN            
      CALL MCKPP_READ_TEMPERATURES_BOTTOM()
-     !WRITE(nuout,*) 'KPP: Called read_bottom_temp, ntime =',kpp_const_fields%ntime
+     ! WRITE(messsage,*) "Called read_bottom_temp, ntime = ", kpp_const_fields%ntime
+     ! CALL mckpp_print(routine, message)
   ENDIF
 
   ! Update reference salinity profiles
   IF (kpp_const_fields%L_UPD_SAL .AND. MOD(kpp_const_fields%ntime-1,kpp_const_fields%ndtupdsal) .EQ. 0 .AND. &
        .NOT. kpp_const_fields%L_INTERP_SAL) THEN
      CALL MCKPP_READ_SALINITY_3D()
-     !WRITE(nuout,*) 'KPP: Called read_salinity, ntime =',kpp_const_fields%ntime
+     ! WRITE(messsage,*) "Called read_salinity, ntime = ", kpp_const_fields%ntime
+     ! CALL mckpp_print(routine, message)
   ELSEIF (kpp_const_fields%L_UPD_SAL .AND. kpp_const_fields%L_INTERP_SAL .AND. &
        MOD(kpp_const_fields%ntime-1,kpp_const_fields%ndt_interp_sal).EQ.0) THEN
      CALL MCKPP_BOUNDARY_INTERPOLATE_SAL()
-     !WRITE(nuout,*) 'KPP: Interpolated ocean salinity, ntime =',kpp_const_fields%ntime
+     ! WRITE(messsage,*) "Interpolated ocean salinity, ntime = ", kpp_const_fields%ntime
+     ! CALL mckpp_print(routine, message)
   ENDIF
 
   ! Update reference temperature profiles
   IF (kpp_const_fields%L_UPD_OCNT .AND. MOD(kpp_const_fields%ntime-1,kpp_const_fields%ndtupdocnt) .EQ. 0 .AND. &
        .NOT. kpp_const_fields%L_INTERP_OCNT) THEN
      CALL MCKPP_READ_TEMPERATURES_3D()
-     !WRITE(nuout,*) 'KPP: Called read_ocean_temperatures, ntime =',kpp_const_fields%ntime
+     ! WRITE(messsage,*) "Called read_ocean_temperatures, ntime = ", kpp_const_fields%ntime
+     ! CALL mckpp_print(routine, message)
   ELSEIF (kpp_const_fields%L_UPD_OCNT .AND. kpp_const_fields%L_INTERP_OCNT .AND. &
        MOD(kpp_const_fields%ntime-1,kpp_const_fields%ndt_interp_ocnt).EQ.0) THEN
      CALL MCKPP_BOUNDARY_INTERPOLATE_TEMP()
-     !WRITE(nuout,*) 'KPP: Interpolated ocean temperatures, ntime =',kpp_const_fields%ntime
+     ! WRITE(messsage,*) "Interpolated ocean temperatures, ntime = ", kpp_const_fields%ntime
+     ! CALL mckpp_print(routine, message)
   ENDIF
 
 END SUBROUTINE MCKPP_BOUNDARY_UPDATE

--- a/mc-kpp_coupling_cam3_step.F90
+++ b/mc-kpp_coupling_cam3_step.F90
@@ -12,6 +12,7 @@ SUBROUTINE MCKPP_COUPLING_CAM3_STEP(srf_state,srfflx)
   USE physconst,    only: latvap
   USE mckpp_types,  only: kpp_3d_fields,kpp_1d_fields,kpp_const_fields
   USE pmgrid,       only: masterproc
+  USE mckpp_log_messages, ONLY: mckpp_print, max_message_len
 
   IMPLICIT NONE
 
@@ -23,27 +24,30 @@ SUBROUTINE MCKPP_COUPLING_CAM3_STEP(srf_state,srfflx)
   REAL(r8) :: sstk(pcols),sst(pcols),ltheat(pcols),shflx(pcols),lhflx(pcols),&
        lwup(pcols),tref(pcols),taux(pcols),tauy(pcols)
   INTEGER :: ncol,ichnk,icol,j,k,indx(pcols),my_npts
-
+  
+  CHARACTER(LEN=24) :: routine = "MCKPP_COUPLING_CAM3_STEP"
+  CHARACTER(LEN=max_message_len) :: message
+    
   ! Increment model time
   kpp_const_fields%ntime=kpp_const_fields%ntime+1
   kpp_const_fields%time=kpp_const_fields%startt+(kpp_const_fields%ntime-1)*&
        kpp_const_fields%dto/kpp_const_fields%spd
   
-  IF (masterproc) &
-       WRITE(6,*) 'MCKPP_COUPLING_CAM3_STEP: Running for timestep ',kpp_const_fields%ntime,' time = ',kpp_const_fields%time
+  WRITE(message,*) 'Running for timestep ',kpp_const_fields%ntime,' time = ',kpp_const_fields%time
+  CALL mckpp_print(routine, message)
 
   ! Update MC-KPP boundary conditions if not first timestep
   IF (kpp_const_fields%ntime .ne. 1) THEN 
-     !IF (masterproc) WRITE(6,*) 'MCKPP_COUPLING_CAM3_STEP: Calling MCKPP_BOUNDARY_UPDATE'
+     ! CALL mckpp_print(routine,'Calling MCKPP_BOUNDARY_UPDATE')
      CALL MCKPP_BOUNDARY_UPDATE
-     !IF (masterproc) WRITE(6,*) 'MCKPP_COUPLING_CAM3_STEP: Returned from MCKPP_BOUNDARY_UPDATE'
+     ! CALL mckpp_print(routine, 'Returned from MCKPP_BOUNDARY_UPDATE')
   ENDIF
 
 
   ! Get CAM3 fluxes
   ! Removed OPENMP loop here because it looked dodgy.
 
-  !IF (masterproc) WRITE(6,*) 'MCKPP_COUPLING_CAM3_STEP: Getting fluxes from CAM atmosphere'
+  ! CALL mckpp_print(routine, 'Getting fluxes from CAM atmosphere')
   DO ichnk=begchunk,endchunk
      ncol=get_ncols_p(ichnk)
 
@@ -62,40 +66,27 @@ SUBROUTINE MCKPP_COUPLING_CAM3_STEP(srf_state,srfflx)
      !kpp_3d_fields(ichnk)%sflux(:,:,5,0)=0.0
 
      IF (my_npts .gt. 0) THEN
-        !WRITE(6,*) 'KPP SST = ',kpp_3d_fields(ichnk)%X(1:ncol,1,1)
+       ! WRITE(message,*) 'KPP SST = ',kpp_3d_fields(ichnk)%X(1:ncol,1,1)
+       ! CALL mckpp_print(routine, message)
         
         IF (kpp_const_fields%ntime .ne. 1) THEN
            ! If not first timestep, use mean value over coupling period
            sstk(1:ncol) = tsocn(1:ncol,ichnk)+kpp_const_fields%TK0
-           !WRITE(6,*) sstk(1:ncol)
-           !sstk(1:ncol) = kpp_3d_fields(ichnk)%sst_cpl(1:ncol)+kpp_const_fields%TK0
+           ! WRITE(message,*) sstk(1:ncol)
+           ! CALL mckpp_print(routine, message)
+           ! sstk(1:ncol) = kpp_3d_fields(ichnk)%sst_cpl(1:ncol)+kpp_const_fields%TK0
         ELSE 
            ! If first timestep, use initial value
            sstk(1:ncol) = kpp_3d_fields(ichnk)%X(1:ncol,1,1)+kpp_const_fields%TK0
         ENDIF
-           ! Delete when means over coupling period work correctly
-           !sstk(1:ncol) = kpp_3d_fields(ichnk)%X(1:ncol,1,1)+kpp_const_fields%TK0
+        ! Delete when means over coupling period work correctly
+        ! sstk(1:ncol) = kpp_3d_fields(ichnk)%X(1:ncol,1,1)+kpp_const_fields%TK0
 
-        !IF (masterproc) THEN 
-        !WRITE(6,*) 'BEFORE FLXOCE:', 'indx= ',indx, 'my_npts= ',my_npts, 'landfrac = ',landfrac(:,ichnk), &
-        !     'pbot= ',srf_state(ichnk)%pbot, 'ubot= ',srf_state(ichnk)%ubot, &
-        !     'vbot= ',srf_state(ichnk)%vbot, 'tbot= ',srf_state(ichnk)%tbot, 'thbot= ',srf_state(ichnk)%thbot, &
-        !     'zbot= ',srf_state(ichnk)%zbot, 'sstk= ',sstk, 'ltheat= ',ltheat, 'taux= ',srfflx(ichnk)%wsx, &
-        !     'tauy= ',srfflx(ichnk)%wsy, 'shflx= ',srfflx(ichnk)%shf, 'lhflx= ',srfflx(ichnk)%lhf, 'lwup= ',srfflx(ichnk)%lwup, &
-        !     'tref= ',srfflx(ichnk)%tref
-           
         CALL FLXOCE(indx,my_npts,srf_state(ichnk)%pbot,srf_state(ichnk)%ubot,&
              srf_state(ichnk)%vbot,srf_state(ichnk)%tbot,srf_state(ichnk)%qbot,&
              srf_state(ichnk)%thbot,srf_state(ichnk)%zbot,sstk,ltheat,&
              srfflx(ichnk)%shf,srfflx(ichnk)%lhf,srfflx(ichnk)%wsx,srfflx(ichnk)%wsy,&
              srfflx(ichnk)%lwup,srfflx(ichnk)%tref)
-             
-        !WRITE(6,*) 'AFTER FLXOCE:', 'indx= ',indx, 'my_npts= ',my_npts, 'landfrac = ',landfrac(:,ichnk), &
-        !     'pbot= ',srf_state(ichnk)%pbot, 'ubot= ',srf_state(ichnk)%ubot, &
-        !     'vbot= ',srf_state(ichnk)%vbot, 'tbot= ',srf_state(ichnk)%tbot, 'thbot= ',srf_state(ichnk)%thbot, &
-        !     'zbot= ',srf_state(ichnk)%zbot, 'sstk= ',sstk, 'ltheat= ',ltheat, 'taux= ',srfflx(ichnk)%wsx, &
-        !     'tauy= ',srfflx(ichnk)%wsy, 'shflx= ',srfflx(ichnk)%shf, 'lhflx= ',srfflx(ichnk)%lhf, 'lwup= ',srfflx(ichnk)%lwup, &
-        !     'tref= ',srfflx(ichnk)%tref                   
         
         DO j=1,my_npts
            icol=indx(j)
@@ -163,43 +154,30 @@ SUBROUTINE MCKPP_COUPLING_CAM3_STEP(srf_state,srfflx)
                    srfflx(ichnk)%lhf(icol)/kpp_const_fields%EL
            ENDIF
            
-                     
-
-              !WRITE(6,*) 'ichnk =',ichnk,'icol = ',icol, 'KPP landsea = ',&
-           !     kpp_3d_fields(ichnk)%landfrac(icol), 'solar = ',kpp_3d_fields(ichnk)%sflux(icol,3,5,0),' nsolar = ',&
-           !     kpp_3d_fields(ichnk)%sflux(icol,4,5,0),' lwup = ',srfflx(ichnk)%lwup(icol),' lwdown_dir = ',&
-           !     srf_state(ichnk)%soll(icol),'lwdown_dif = ',srf_state(ichnk)%solld(icol),&
-           !     ' lhflx = ',srfflx(ichnk)%lhf(icol),' shflx = ',srfflx(ichnk)%shf(icol)
-           !WRITE(6,*) 'sstk =',sstk(icol),' L_OCEAN=',kpp_3d_fields(ichnk)%L_OCEAN(icol),' cplwght = ',&
-           !     kpp_3d_fields(ichnk)%cplwght(icol)
-           !WRITE(6,*) 'taux= ',kpp_3d_fields(ichnk)%sflux(icol,1,5,0),&
-           !     ' tauy= ',kpp_3d_fields(ichnk)%sflux(icol,2,5,0),&
-           !     ' swf= ',kpp_3d_fields(ichnk)%sflux(icol,3,5,0),&
-           !     ' lwf= ',kpp_3d_fields(ichnk)%sflux(icol,4,5,0),&
-           !     ' rain= ',kpp_3d_fields(ichnk)%sflux(icol,6,5,0)                   
         ENDDO        
         !STOP
      ENDIF
   ENDDO
-  !IF (masterproc) WRITE(6,*) 'MCKPP_COUPLING_CAM3_STEP: Done getting fluxes from CAM atmosphere'
+  ! CALL mckpp_print(routine, 'Done getting fluxes from CAM atmosphere')
 
   ! Call MC-KPP physics
-  !IF (masterproc) WRITE(6,*) 'MCKPP_COUPLING_CAM3_STEP: Calling MCKPP_PHYSICS_DRIVER'
+  ! CALL mckpp_print(routine, 'Calling MCKPP_PHYSICS_DRIVER')
   CALL MCKPP_PHYSICS_DRIVER
-  !IF (masterproc) WRITE(6,*) 'MCKPP_COUPLING_CAM3_STEP: Returned from MCKPP_PHYSICS_DRIVER'
+  ! CALL mckpp_print(routine, 'Returned from MCKPP_PHYSICS_DRIVER')
 
   ! Write MC-KPP output if necessary
-  !IF (masterproc) WRITE(6,*) 'MCKPP_COUPLING_CAM3_STEP: Calling MCKPP_OUTPUT_CONTROL'
+  ! CALL mckpp_print(routine, 'Calling MCKPP_OUTPUT_CONTROL')
   CALL MCKPP_OUTPUT_CONTROL
-  !IF (masterproc) WRITE(6,*) 'MCKPP_COUPLING_CAM3_STEP: Returned from MCKPP_OUTPUT_CONTROL'
+  ! CALL mckpp_print(routine, 'Returned from MCKPP_OUTPUT_CONTROL')
 
   ! Write MC-KPP checkpoint files if necessary
   CALL MCKPP_RESTART_CONTROL
 
   ! Output SST and ice back to CAM
-  !IF (masterproc) WRITE(6,*) 'MCKPP_COUPLING_CAM3_STEP: Sending SST and ice back to CAM atmosphere'
+  ! CALL mckpp_print(routine, 'Sending SST and ice back to CAM atmosphere')
   CALL MCKPP_COUPLING_CAM3_OUTPUT(srfflx)
-  IF (masterproc) WRITE(6,*) 'MCKPP_COUPLING_CAM3_STEP: Finished coupling for timestep ',kpp_const_fields%ntime
+  WRITE(message,*) 'Finished coupling for timestep ',kpp_const_fields%ntime
+  CALL mckpp_print(routine, message)
 
   RETURN
 END SUBROUTINE MCKPP_COUPLING_CAM3_STEP
@@ -213,6 +191,7 @@ SUBROUTINE MCKPP_COUPLING_CAM3_OUTPUT(srfflx)
   USE phys_grid, only: get_ncols_p
   USE physconst, only: latvap
   USE constituents, only: pcnst,pnats
+  USE mckpp_log_messages, ONLY: mckpp_print, max_message_len
 
   IMPLICIT NONE
 
@@ -221,6 +200,9 @@ SUBROUTINE MCKPP_COUPLING_CAM3_OUTPUT(srfflx)
   REAL(r8) :: sst_out(PCOLS),& ! SST in deg C internally, converted to K before output as Tsocn
        ltheat(PCOLS),blended_sst(PCOLS)
 
+  CHARACTER(LEN=26) :: routine = "MCKPP_COUPLING_CAM3_OUTPUT"
+  CHARACTER(LEN=max_message_len) :: message
+    
   DO ichnk=begchunk,endchunk
      ncol=get_ncols_p(ichnk)
      
@@ -251,8 +233,9 @@ SUBROUTINE MCKPP_COUPLING_CAM3_OUTPUT(srfflx)
            ELSE IF (kpp_3d_fields(ichnk)%cplwght(icol) .eq. 0) THEN
               blended_sst(icol)=kpp_3d_fields(ichnk)%sst(icol)
            ELSE
-              WRITE(6,*) 'MCKPP_COUPLING_CAM3_OUTPUT: Invalid value of coupling weight at ichnk = ',ichnk, &
-                   'icol = ',icol,' coupling weight = ',kpp_3d_fields(ichnk)%cplwght(icol)
+              WRITE(message,*) 'Invalid value of coupling weight at ichnk = ',ichnk, &
+                  'icol = ',icol,' coupling weight = ',kpp_3d_fields(ichnk)%cplwght(icol)
+              CALL mckpp_print_warning(routine, message) 
            ENDIF
            
            ! Put MC-KPP ice fraction to CAM ice fraction

--- a/mc-kpp_fluxes_ntflux.F90
+++ b/mc-kpp_fluxes_ntflux.F90
@@ -5,6 +5,7 @@ SUBROUTINE mckpp_fluxes_ntflux(kpp_1d_fields,kpp_const_fields)
 #else 
   USE mckpp_data_fields, ONLY: kpp_1d_type, kpp_const_type
 #endif 
+  USE mckpp_log_messages, ONLY: mckpp_print, max_message_len
   USE mckpp_parameters, ONLY: nz
 
   IMPLICIT NONE
@@ -14,8 +15,11 @@ SUBROUTINE mckpp_fluxes_ntflux(kpp_1d_fields,kpp_const_fields)
   EXTERNAL MCKPP_FLUXES_SWDK
   TYPE(kpp_1d_type) :: kpp_1d_fields
   TYPE(kpp_const_type) :: kpp_const_fields
+  CHARACTER(LEN=31) :: routine = "MCKPP_FLUXES_NTFLUX"
+  CHARACTER(LEN=max_message_len) :: message
   
-  !WRITE(6,*) 'MCKPP_FLUXES_NTFLUX at time = ',kpp_const_fields%ntime
+  ! WRITE(message,*) "At time = ", kpp_const_fields%ntime
+  ! CALL mckpp_print(routine, message)
   IF (kpp_const_fields%ntime .le. 1) THEN
      DO k=0,NZ
         kpp_1d_fields%swdk_opt(k)=MCKPP_FLUXES_SWDK(-kpp_const_fields%dm(k),kpp_1d_fields%jerlov)

--- a/mc-kpp_initialize_couplingweight.F90
+++ b/mc-kpp_initialize_couplingweight.F90
@@ -14,6 +14,7 @@ SUBROUTINE MCKPP_INITIALIZE_COUPLINGWEIGHT()
 #else
   USE mckpp_data_fields, ONLY: kpp_3d_fields, kpp_const_fields
 #endif  
+  USE mckpp_log_messages, ONLY: mckpp_print, max_message_len
   USE mckpp_parameters, ONLY: nx_globe, ny_globe
 
   IMPLICIT NONE
@@ -29,10 +30,11 @@ SUBROUTINE MCKPP_INITIALIZE_COUPLINGWEIGHT()
   INTEGER ipoint_globe
 
 #include <netcdf.inc>
-!#include <couple.com>
   
   REAL*4 ixx, jyy, cplwght_in(NX_GLOBE,NY_GLOBE)
-  
+  CHARACTER(LEN=31) :: routine = "MCKPP_INITIALIZE_COUPLINGWEIGHT"
+  CHARACTER(LEN=max_message_len) :: message
+
 !  If L_CPLWGHT has been set, then we will use the
 !  NetCDF file to set values of cplwght over the
 !  entire globe.
@@ -49,7 +51,7 @@ SUBROUTINE MCKPP_INITIALIZE_COUPLINGWEIGHT()
   start(2) = 1
   count(1) = NX_GLOBE
   count(2) = NY_GLOBE
-  WRITE(6,*) 'MCKPP_INITIALIZE_COUPLINGWEIGHT: Reading coupling weight (alpha)'
+  CALL mckpp_print(routine, "Reading coupling weight (alpha)")
   status=NF_INQ_VARID(ncid_cplwght,'alpha',cplwght_varid)
   IF (status .NE. NF_NOERR) CALL MCKPP_HANDLE_ERR(status)
   status=NF_GET_VARA_REAL(ncid_cplwght,cplwght_varid,start,count,cplwght_in)
@@ -109,10 +111,11 @@ SUBROUTINE MCKPP_INITIALIZE_COUPLINGWEIGHT()
 !!$           IF (kpp_3d_fields%L_OCEAN(ipoint) .and. kpp_3d_fields%ocdepth(ipoint) .gt. 100) THEN
 !!$              kpp_3d_fields%L_OCEAN(ipoint)=.FALSE.
 !!$              kpp_3d_fields%cplwght(ipoint_globe)=0
-!!$              WRITE(6,*) 'Overwriting coupling mask at'
-!!$              WRITE(6,*) 'ixx=',ixx,'jyy=',jyy,'ipoint_globe=',ipoint_globe,'ipoint=',ipoint,'cplwght=',&
+!!$              CALL mckpp_print(routine, "Overwriting coupling mask at: ")
+!!$              WRITE(message,*) 'ixx=',ixx,'jyy=',jyy,'ipoint_globe=',ipoint_globe,'ipoint=',ipoint,'cplwght=',&
 !!$                   kpp_3d_fields%cplwght(ipoint_globe),'ocdepth=',kpp_3d_fields%ocdepth(ipoint),&
 !!$                   'L_OCEAN=',kpp_3d_fields%L_OCEAN(ipoint)
+!!$              CALL mckpp_print(routine, message) 
 !!$           ENDIF
 !!$        ELSE
 !!$           ! Point is outside coupling domain.

--- a/mc-kpp_initialize_fields.F90
+++ b/mc-kpp_initialize_fields.F90
@@ -77,7 +77,7 @@ SUBROUTINE MCKPP_INITIALIZE_FIELDS()
    ELSEIF (.NOT. kpp_const_fields%L_REGGRID .AND. .NOT. kpp_const_fields%L_LANDSEA) THEN
      message = "If you set L_REGGRID=.FALSE., you must specify a land-sea mask file from which" &
          // " to read the locations of the gridpoints in the horizontal."
-     CALL mckpp_warning(routine, message)
+     CALL mckpp_print_warning(routine, message)
   ENDIF
 #endif
 

--- a/mc-kpp_initialize_fields.F90
+++ b/mc-kpp_initialize_fields.F90
@@ -75,8 +75,8 @@ SUBROUTINE MCKPP_INITIALIZE_FIELDS()
         ENDDO
      ENDDO
    ELSEIF (.NOT. kpp_const_fields%L_REGGRID .AND. .NOT. kpp_const_fields%L_LANDSEA) THEN
-     message = "If you set L_REGGRID=.FALSE., you must specify a land-sea mask file from which" &
-         // " to read the locations of the gridpoints in the horizontal."
+     WRITE(message,*) "If you set L_REGGRID=.FALSE., you must specify a land-sea mask file from which", & 
+         " to read the locations of the gridpoints in the horizontal."
      CALL mckpp_print_warning(routine, message)
   ENDIF
 #endif

--- a/mc-kpp_initialize_fields.F90
+++ b/mc-kpp_initialize_fields.F90
@@ -15,7 +15,8 @@ SUBROUTINE MCKPP_INITIALIZE_FIELDS()
   USE mckpp_data_fields, ONLY: kpp_3d_fields, kpp_const_fields, &
       mckpp_allocate_3d_fields
 #endif
-  USE mckpp_parameters, ONLY: nx, ny, npts, nuout, nuerr
+  USE mckpp_log_messages, ONLY: mckpp_print, mckpp_print_warning, max_message_len
+  USE mckpp_parameters, ONLY: nx, ny, npts
 
   IMPLICIT NONE
 
@@ -24,6 +25,8 @@ SUBROUTINE MCKPP_INITIALIZE_FIELDS()
   REAL(r8) :: clat1(pcols),clon1(pcols)
 #endif
   INTEGER :: iy,ix,ipt
+  CHARACTER(LEN=23) :: routine = "MCKPP_INITIALIZE_FIELDS"
+  CHARACTER(LEN=max_message_len) :: message 
 
 #ifndef MCKPP_CAM3
   CALL mckpp_allocate_3d_fields()
@@ -49,15 +52,15 @@ SUBROUTINE MCKPP_INITIALIZE_FIELDS()
      kpp_3d_fields(ichnk)%dlon(:)=clon1*360./kpp_const_fields%twopi    
   ENDDO
   IF (kpp_const_fields%L_LANDSEA) THEN
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Calling MCKPP_INITIALIZE_LANDSEA'
+     CALL mckpp_print(routine, "Calling MCKPP_INITIALIZE_LANDSEA")
      CALL MCKPP_INITIALIZE_LANDSEA()
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Returned from MCKPP_INITIALIZE_LANDSEA'
+     CALL mckpp_print(routine, "Returned from MCKPP_INITIALIZE_LANDSEA")
   ENDIF
 #elif CFS
   IF (L_LANDSEA) CALL read_landsea_global()
 #else
   IF (kpp_const_fields%L_LANDSEA) THEN
-     WRITE(nuout,*) "MCKPP_INITIALIZE_FIELDS: Calling MCKPP_INITIALIZE_LANDSEA"
+     CALL mckpp_print(routine, "Calling MCKPP_INITIALIZE_LANDSEA")
      kpp_3d_fields%dlat(1)=kpp_const_fields%alat
      kpp_3d_fields%dlon(1)=kpp_const_fields%alon
      CALL MCKPP_INITIALIZE_LANDSEA()
@@ -71,29 +74,25 @@ SUBROUTINE MCKPP_INITIALIZE_FIELDS()
            kpp_3d_fields%L_OCEAN(ipt)=.TRUE.
         ENDDO
      ENDDO
-  ELSEIF (.NOT. kpp_const_fields%L_REGGRID .AND. .NOT. kpp_const_fields%L_LANDSEA) THEN
-     WRITE(nuerr,*) 'KPP : If you set L_REGGRID=.FALSE., you must',&
-          ' specify a land-sea mask file from which to read',&
-          ' the locations of the gridpoints in the horizontal.'
+   ELSEIF (.NOT. kpp_const_fields%L_REGGRID .AND. .NOT. kpp_const_fields%L_LANDSEA) THEN
+     message = "If you set L_REGGRID=.FALSE., you must specify a land-sea mask file from which" &
+         // " to read the locations of the gridpoints in the horizontal."
+     CALL mckpp_warning(routine, message)
   ENDIF
 #endif
 
   ! Initialize the vertical grid
-#ifdef MCKPP_CAM3
-  IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Calling MCKPP_INITIALIZE_GEOGRAPHY'
+  CALL mckpp_print(routine, "Calling MCKPP_INITIALIZE_GEOGRAPHY")
   CALL MCKPP_INITIALIZE_GEOGRAPHY()
-  IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Returned from MCKPP_INITIALIZE_GEOGRAPHY'
-#else
-  CALL MCKPP_INITIALIZE_GEOGRAPHY()
-#endif  
+  CALL mckpp_print(routine, "Returned from MCKPP_INITIALIZE_GEOGRAPHY")
 
   ! Initialize coupling weights   
 #if (defined OASIS2 || defined OASIS3 || defined CFS)
   CALL MCKPP_INITIALIZE_COUPLINGWEIGHT()
 #elif (defined MCKPP_CAM3)
-  IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Calling MCKPP_INITIALIZE_COUPLINGWEIGHT'
+  CALL mckpp_print(routine, "Calling MCKPP_INITIALIZE_COUPLINGWEIGHT") 
   CALL MCKPP_INITIALIZE_COUPLINGWEIGHT()
-  IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Returned from MCKPP_INITIALIZE_COUPLINGWEIGHT'
+  CALL mckpp_print(routine, "Returned from MCKPP_INITIALIZE_COUPLINGWEIGHT")
   ! Initialize coupling-period mean fluxes and SST fields
   DO ichnk=begchunk,endchunk
      ncol=get_ncols_p(ichnk)
@@ -106,198 +105,123 @@ SUBROUTINE MCKPP_INITIALIZE_FIELDS()
 
   ! Initialize advection options
   IF (kpp_const_fields%L_ADVECT) THEN
-#ifdef MCKPP_CAM3
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Calling MCKPP_INITIALIZE_ADVECTION'
+     CALL mckpp_print(routine, "Calling MCKPP_INITIALIZE_ADVECTION")
      CALL MCKPP_INITIALIZE_ADVECTION()
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Returned from MCKPP_INITIALIZE_ADVECTION'
+     CALL mckpp_print(routine, "Returned from MCKPP_INITIALIZE_ADVECTION")
   ELSE
+#ifdef MCKPP_CAM3
      DO ichnk=begchunk,endchunk
         ncol=get_ncols_p(ichnk)
         kpp_3d_fields(ichnk)%nmodeadv(1:ncol,:)=0
-     ENDDO
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: No advection has been specified.'
-  ENDIF
+      ENDDO
 #else
-     CALL MCKPP_INITIALIZE_ADVECTION()
-  ELSE
      DO ipt=1,npts
         kpp_3d_fields%nmodeadv(ipt,1)=0
         kpp_3d_fields%nmodeadv(ipt,2)=0
      ENDDO
-     write(6,*) 'KPP : No advection has been specified'
-  ENDIF
-#endif
+#endif 
+     CALL mckpp_print(routine, "No advection has been specified.") 
+   ENDIF
 
   ! Initialize relaxation of SST, temperature and/or salinity
   IF (kpp_const_fields%L_RELAX_SST .OR. kpp_const_fields%L_RELAX_SAL &
        .OR. kpp_const_fields%L_RELAX_OCNT) THEN     
-#ifdef MCKPP_CAM3
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Calling MCKPP_INITIALIZE_RELAXATION'
+     CALL mckpp_print(routine, "Calling MCKPP_INITIALIZE_RELAXATION")
      CALL MCKPP_INITIALIZE_RELAXATION()
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Returned from MCKPP_INITIALIZE_RELAXATION'
-#else
-     CALL MCKPP_INITIALIZE_RELAXATION()
-#endif     
+     CALL mckpp_print(routine, "Returned from MCKPP_INITIALIZE_RELAXATION")
   ENDIF
 
   ! Initialize water type for optical properties of seawater
-#ifdef MCKPP_CAM3
-  IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Calling MCKPP_INITIALIZE_OPTICS'
+  CALL mckpp_print(routine, "Calling MCKPP_INITIALIZE_OPTICS")
   CALL MCKPP_INITIALIZE_OPTICS()
-  IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Returned from MCKPP_INITIALIZE_OPTICS' 
-#else
-  CALL MCKPP_INITIALIZE_OPTICS()
-#endif
+  CALL mckpp_print(routine, "Returned from MCKPP_INITIALIZE_OPTICS")
 
   ! Initialize ocean profiles
   IF (kpp_const_fields%L_RESTART) THEN     
-#ifdef MCKPP_CAM3
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Calling MCKPP_RESTART_IO_READ'
+     CALL mckpp_print(routine, "Calling MCKPP_RESTART_IO_READ")
      ! Still needs scattering code
      CALL MCKPP_RESTART_IO_READ_NETCDF()
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Returned from MCKPP_RESTART_IO_READ'
-#else
-     CALL MCKPP_RESTART_IO_READ_NETCDF()
-#endif
+     CALL mckpp_print(routine, "Returned from MCKPP_RESTART_IO_READ")
   ELSE
-#ifdef MCKPP_CAM3
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Calling MCKPP_INITIALIZE_OCEAN_PROFILES'
+     CALL mckpp_print(routine, "Calling MCKPP_INITIALIZE_OCEAN_PROFILES")
      CALL MCKPP_INITIALIZE_OCEAN_PROFILES()
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Returned from MCKPP_INITIALIZE_OCEAN_PROFILES'
-#else
-     CALL MCKPP_INITIALIZE_OCEAN_PROFILES()
-#endif  
+     CALL mckpp_print(routine, "Returned from MCKPP_INITIALIZE_OCEAN_PROFILES")
   ENDIF
   
   ! Initialize boundary conditions
   IF (kpp_const_fields%L_CLIMSST) THEN     
-#ifdef MCKPP_CAM3
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Calling MCKPP_READ_SST'
+     CALL mckpp_print(routine, "Calling MCKPP_READ_SST")
      CALL MCKPP_READ_SST()
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Returned from MCKPP_READ_SST'
-#else
-     CALL MCKPP_READ_SST()
-#endif     
+     CALL mckpp_print(routine, "Returned from MCKPP_READ_SST")
   ENDIF
 
   IF (kpp_const_fields%L_CLIMICE) THEN    
-#ifdef MCKPP_CAM3
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Calling MCKPP_READ_ICE'
+     CALL mckpp_print(routine, "Calling MCKPP_READ_ICE")
      CALL MCKPP_READ_ICE()
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Returned from MCKPP_READ_ICE'
-#else
-     CALL MCKPP_READ_ICE()
-#endif    
+     CALL mckpp_print(routine, "Returned from MCKPP_READ_ICE")
   ENDIF
 !!$    !IF (L_CLIMCURR) CALL read_surface_currents(kpp_3d_fields,kpp_const_fields)
   
   IF (kpp_const_fields%L_FCORR_WITHZ) THEN     
-#ifdef MCKPP_CAM3
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Calling MCKPP_READ_FCORR_3D'
+     CALL mckpp_print(routine, "Calling MCKPP_READ_FCORR_3D")
      CALL MCKPP_READ_FCORR_3D()
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Returned from MCKPP_READ_FCORR_3D'
-#else
-     CALL MCKPP_READ_FCORR_3D()
-#endif     
+     CALL mckpp_print(routine, "Returned from MCKPP_READ_FCORR_3D")
   ELSEIF (kpp_const_fields%L_FCORR) THEN      
-#ifdef MCKPP_CAM3
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Calling MCKPP_READ_FCORR_2D'
+     CALL mckpp_print(routine, "Calling MCKPP_READ_FCORR_2D")
      CALL MCKPP_READ_FCORR_2D()
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Returned from MCKPP_READ_FCORR_2D'
-#else
-     CALL MCKPP_READ_FCORR_2D()
-#endif  
+     CALL mckpp_print(routine, "Returned from MCKPP_READ_FCORR_2D")
   ENDIF
 
   IF (kpp_const_fields%L_SFCORR_WITHZ) THEN   
-#ifdef MCKPP_CAM3
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Calling MCKPP_READ_SFCORR_3D'
+     CALL mckpp_print(routine, "Calling MCKPP_READ_SFCORR_3D")
      CALL MCKPP_READ_SFCORR_3D()
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Returned from MCKPP_READ_SFCORR_3D'
-#else
-     CALL MCKPP_READ_SFCORR_3D()
-#endif   
+     CALL mckpp_print(routine, "Returned from MCKPP_READ_SFCORR_3D")
   ELSEIF (kpp_const_fields%L_SFCORR) THEN
-#ifdef MCKPP_CAM3
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Calling MCKPP_READ_SFCORR_2D'
+     CALL mckpp_print(routine, "Calling MCKPP_READ_SFCORR_2D")
      CALL MCKPP_READ_SFCORR_2D()
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Returned from MCKPP_READ_SFCORR_2D'
-#else
-     CALL MCKPP_READ_SFCORR_2D()
-#endif
+     CALL mckpp_print(routine, "Returned from MCKPP_READ_SFCORR_2D")
   ENDIF
 
   IF (kpp_const_fields%L_VARY_BOTTOM_TEMP) THEN     
-#ifdef MCKPP_CAM3
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Calling MCKPP_READ_TEMPERATURES_BOTTOM'
+     CALL mckpp_print(routine, "Calling MCKPP_READ_TEMPERATURES_BOTTOM")
      CALL MCKPP_READ_TEMPERATURES_BOTTOM()
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Returned from MCKPP_READ_TEMPERATURES_BOTTOM'
-#else
-     CALL MCKPP_READ_TEMPERATURES_BOTTOM()
-#endif 
+     CALL mckpp_print(routine, "Returned from MCKPP_READ_TEMPERATURES_BOTTOM")
   ENDIF
 
   !!! THESE SHOULD NOT BE CALLED IF DOING L_INTERP_OCNT / L_INTERP_SAL !!!
 
   IF (kpp_const_fields%L_RELAX_OCNT .AND. .NOT. kpp_const_fields%L_INTERP_OCNT) THEN 
-#ifdef MCKPP_CAM3
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Calling MCKPP_READ_TEMPERATURES_3D'
+     CALL mckpp_print(routine, "Calling MCKPP_READ_TEMPERATURES_3D")
      CALL MCKPP_READ_TEMPERATURES_3D()
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Returned from MCKPP_READ_TEMPERATURES_3D'
-#else
-     CALL MCKPP_READ_TEMPERATURES_3D()
-#endif     
+     CALL mckpp_print(routine, "Returned from MCKPP_READ_TEMPERATURES_3D")
   ELSEIF (kpp_const_fields%L_RELAX_OCNT .AND. kpp_const_fields%L_INTERP_OCNT) THEN     
-#ifdef MCKPP_CAM3
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Calling MCKPP_BOUNDARY_INTERPOLATE_TEMP'
+     CALL mckpp_print(routine, "Calling MCKPP_BOUNDARY_INTERPOLATE_TEMP")
      CALL MCKPP_BOUNDARY_INTERPOLATE_TEMP()
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Returned from MCKPP_BOUNDARY_INTERPOLATE_TEMP'
-#else
-     CALL MCKPP_BOUNDARY_INTERPOLATE_TEMP()
-#endif   
+     CALL mckpp_print(routine, "Returned from MCKPP_BOUNDARY_INTERPOLATE_TEMP")
   ENDIF
 
   IF (kpp_const_fields%L_RELAX_SAL .AND. .NOT. kpp_const_fields%L_INTERP_SAL) THEN
-#ifdef MCKPP_CAM3
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Calling MCKPP_READ_SALINITY_3D' 
+     CALL mckpp_print(routine, "Calling MCKPP_READ_SALINITY_3D")
      CALL MCKPP_READ_SALINITY_3D()
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Returned from MCKPP_READ_SALINITY_3D'  
-#else
-     CALL MCKPP_READ_SALINITY_3D()
-#endif   
+     CALL mckpp_print(routine, "Returned from MCKPP_READ_SALINITY_3D")
   ELSEIF (kpp_const_fields%L_RELAX_SAL .AND. kpp_const_fields%L_INTERP_SAL) THEN
-#ifdef MCKPP_CAM3     
      CALL MCKPP_BOUNDARY_INTERPOLATE_SAL()
-#else
-     CALL MCKPP_BOUNDARY_INTERPOLATE_SAL()
-#endif
   ENDIF
 
-#ifdef MCKPP_CAM3
-  IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Calling MCKPP_INITIALIZE_FLUXES_VARIABLES'
+  CALL mckpp_print(routine, "Calling MCKPP_INITIALIZE_FLUXES_VARIABLES")
   CALL MCKPP_INITIALIZE_FLUXES_VARIABLES()
-  IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Returned from MCKPP_INITIALIZE_FLUXES_VARIABLES'
-#else
-  CALL MCKPP_INITIALIZE_FLUXES_VARIABLES()
-#endif
+  CALL mckpp_print(routine, "Returned from MCKPP_INITIALIZE_FLUXES_VARIABLES")
 
   ! Isothermal detection routine requires 3D ocean temperature and salinity fields
   IF (kpp_const_fields%L_NO_ISOTHERM .AND. .NOT. kpp_const_fields%L_RELAX_SAL &
        .AND. .NOT. kpp_const_fields%L_RELAX_OCNT) THEN         
-#ifdef MCKPP_CAM3
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Calling MCKPP_READ_TEMPERATURES_3D'
+     CALL mckpp_print(routine, " Calling MCKPP_READ_TEMPERATURES_3D")
      CALL MCKPP_READ_TEMPERATURES_3D()
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Returned from MCKPP_READ_TEMPERATURES_3D'
-#else
-     CALL MCKPP_READ_TEMPERATURES_3D()
-#endif
-#ifdef MCKPP_CAM3
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Calling MCKPP_READ_SALINITY_3D'
+     CALL mckpp_print(routine, "Returned from MCKPP_READ_TEMPERATURES_3D")
+
+     CALL mckpp_print(routine, "Calling MCKPP_READ_SALINITY_3D")
      CALL MCKPP_READ_SALINITY_3D()
-     IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Returned from MCKPP_SALINITY_3D'
-#else
-     CALL MCKPP_READ_SALINITY_3D()
-#endif
+     CALL mckpp_print(routine, "Returned from MCKPP_SALINITY_3D")
   ENDIF
   
   ! L_INTERP_OCNT and L_INTERP_SAL imply L_PERIODIC_OCNT and L_PERIODIC_SAL,
@@ -312,16 +236,12 @@ SUBROUTINE MCKPP_INITIALIZE_FIELDS()
 #endif  
 
   kpp_const_fields%ntime=0
-  !WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Calling MCKPP_PHYSICS_LOOKUP'
+  ! CALL mckpp_print(routine, "Calling MCKPP_PHYSICS_LOOKUP")
   CALL MCKPP_PHYSICS_LOOKUP(kpp_const_fields)
-  !WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Returned from MCKPP_PHYSICS_LOOKUP'
+  ! CALL mckpp_print(routine, "Returned from MCKPP_PHYSICS_LOOKUP")
 
-#ifdef MCKPP_CAM3
-  IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Calling MCKPP_INITIALIZE_OCEAN_MODEL'
+  CALL mckpp_print(routine, "Calling MCKPP_INITIALIZE_OCEAN_MODEL")
   CALL MCKPP_INITIALIZE_OCEAN_MODEL()
-  IF (masterproc) WRITE(nuout,*) 'MCKPP_INITIALIZE_FIELDS: Returned from MCKPP_INITIALIZE_OCEAN_MODEL'
-#else
-  CALL MCKPP_INITIALIZE_OCEAN_MODEL()
-#endif
+  CALL mckpp_print(routine, "Returned from MCKPP_INITIALIZE_OCEAN_MODEL")
 
 END SUBROUTINE MCKPP_INITIALIZE_FIELDS

--- a/mc-kpp_initialize_fluxes.F90
+++ b/mc-kpp_initialize_fluxes.F90
@@ -46,7 +46,8 @@ end SUBROUTINE mckpp_initialize_fluxes_variables
 ! No support for data atmosphere when coupled to CAM3
 #ifndef MCKPP_CAM3 
 SUBROUTINE mckpp_initialize_fluxes_file()
-  
+
+  USE mckpp_log_messages, ONLY: mckpp_print, max_message_len
   USE mckpp_data_fields, ONLY: kpp_const_fields
 
   IMPLICIT NONE
@@ -54,12 +55,15 @@ SUBROUTINE mckpp_initialize_fluxes_file()
 #include <netcdf.inc>
   
   INTEGER status,index(3)
-  
+  CHARACTER(LEN=23) :: routine = "MCKPP_INITIALIZE_FLUXES"
+  CHARACTER(LEN=max_message_len) :: message
+
   index(1)=1
   index(2)=1
   index(3)=1
   
-  WRITE(6,*) 'MCKPP_INITIALIZE_FLUXES: Opening file ',kpp_const_fields%forcing_file
+  WRITE(message,*) "Opening file ", kpp_const_fields%forcing_file
+  CALL mckpp_print(routine, message)
   status=NF_OPEN(kpp_const_fields%forcing_file,0,kpp_const_fields%flx_ncid)
   IF (status .NE. NF_NOERR) CALL MCKPP_HANDLE_ERR(status)
   
@@ -84,6 +88,5 @@ SUBROUTINE mckpp_initialize_fluxes_file()
        index,kpp_const_fields%flx_first_timein)
   IF (status .NE. NF_NOERR) CALL MCKPP_HANDLE_ERR(status)
             
-  RETURN
 END SUBROUTINE mckpp_initialize_fluxes_file
 #endif

--- a/mc-kpp_initialize_geography.F90
+++ b/mc-kpp_initialize_geography.F90
@@ -8,6 +8,7 @@ SUBROUTINE mckpp_initialize_geography()
 #else
   USE mckpp_data_fields, ONLY: kpp_const_fields, kpp_3d_fields
 #endif /*MCKPP_CAM3*/
+  USE mckpp_log_messages, ONLY: mckpp_print, max_message_len
   USE mckpp_parameters, ONLY: nz, nzp1, npts
 
   IMPLICIT NONE
@@ -22,10 +23,13 @@ SUBROUTINE mckpp_initialize_geography()
   REAL sumh,hsum,dfac,sk
   REAL*4 vgrid_in(NZ)
   INTEGER i,ipt,ncid,status,dimid,varid
+  CHARACTER(LEN=26) :: routine = "MCKPP_INITIALIZE_GEOGRAPHY"
+  CHARACTER(LEN=max_message_len) :: message
 
   ! define vertical grid fields
   IF (kpp_const_fields%L_VGRID_FILE) THEN 
-     !WRITE(6,*) 'Reading vertical grid from file ',kpp_const_fields%vgrid_file
+     ! WRITE(message,*) "Reading vertical grid from file ", kpp_const_fields%vgrid_file
+     ! CALL mckpp_print(routine, message)
      status=NF_OPEN(kpp_const_fields%vgrid_file,0,ncid)
      IF (status.ne.NF_NOERR) CALL MCKPP_HANDLE_ERR(status)
      status=NF_INQ_VARID(ncid,'d',varid)
@@ -45,8 +49,9 @@ SUBROUTINE mckpp_initialize_geography()
      IF (status.ne.NF_NOERR) CALL MCKPP_HANDLE_ERR(status)
      status=NF_CLOSE(ncid)
      kpp_const_fields%DMAX=-1.*(kpp_const_fields%zm(NZ)-kpp_const_fields%hm(NZ))
-     !WRITE(6,*) 'hm = ',kpp_const_fields%hm,'zm =',kpp_const_fields%zm,' dm = ',&
-     !     kpp_const_fields%dm,' DMAX = ',kpp_const_fields%DMAX
+     ! WRITE(message,*) 'hm = ', kpp_const_fields%hm, 'zm = ', kpp_const_fields%zm,' &
+     !     dm = ', kpp_const_fields%dm,' DMAX = ', kpp_const_fields%DMAX
+     ! CALL mckpp_print(routine, message)
   ELSE     
      IF (kpp_const_fields%L_STRETCHGRID) THEN
         sumh = 0.0

--- a/mc-kpp_initialize_landsea.F90
+++ b/mc-kpp_initialize_landsea.F90
@@ -14,6 +14,7 @@ SUBROUTINE mckpp_initialize_landsea()
 #else
   USE mckpp_data_fields, ONLY: kpp_3d_fields, kpp_const_fields
 #endif
+  USE mckpp_log_messages, ONLY: mckpp_print, max_message_len
   USE mckpp_parameters, ONLY: npts
  
   IMPLICIT NONE
@@ -29,12 +30,14 @@ SUBROUTINE mckpp_initialize_landsea()
 #endif
 
   INTEGER :: ipt,status,ncid_landsea
+  CHARACTER(LEN=24) :: routine = "MCKPP_INITIALIZE_LANDSEA"
+  CHARACTER(LEN=max_message_len) :: message
   
   IF (kpp_const_fields%L_LANDSEA) THEN
-     WRITE(6,*) kpp_const_fields%landsea_file
+     WRITE(message,*) "Reading", kpp_const_fields%landsea_file
+     CALL mckpp_print(routine, message)
      status=NF_OPEN(kpp_const_fields%landsea_file,0,ncid_landsea)
      IF (status .NE. NF_NOERR) CALL MCKPP_HANDLE_ERR(status)    
-     WRITE(6,*) 'Initialized landsea file',ncid_landsea
      
 #ifdef MCKPP_CAM3
      IF (masterproc) THEN 
@@ -43,7 +46,8 @@ SUBROUTINE mckpp_initialize_landsea()
      ENDIF
      CALL scatter_field_to_chunk(1,1,1,PLON,ocdepth,ocdepth_chunk(1,begchunk))
      CALL scatter_field_to_chunk(1,1,1,PLON,landsea,landsea_chunk(1,begchunk))
-     WRITE(6,*) ocdepth_chunk(2,begchunk),landsea_chunk(2,begchunk)
+     WRITE(message,*) ocdepth_chunk(2,begchunk),landsea_chunk(2,begchunk)
+     CALL mckpp_print(routine, message)
      DO ichnk=begchunk,endchunk
         ncol=get_ncols_p(ichnk)
         kpp_3d_fields(ichnk)%ocdepth(:)=ocdepth_chunk(:,ichnk)
@@ -67,7 +71,7 @@ SUBROUTINE mckpp_initialize_landsea()
      ENDDO     
      call MCKPP_READ_PAR(ncid_landsea,'max_depth',1,1,kpp_3d_fields%ocdepth)
 #endif     
-     WRITE(6,*) 'Read landsea mask'     
+     CALL mckpp_print(routine, "Read landsea mask") 
      status=NF_CLOSE(ncid_landsea)
      IF (status .NE. NF_NOERR) CALL MCKPP_HANDLE_ERR(status)
   ELSE
@@ -76,5 +80,4 @@ SUBROUTINE mckpp_initialize_landsea()
      ENDDO
   ENDIF
   
-  RETURN
 END SUBROUTINE mckpp_initialize_landsea

--- a/mc-kpp_initialize_namelists.F90
+++ b/mc-kpp_initialize_namelists.F90
@@ -89,9 +89,9 @@ SUBROUTINE MCKPP_INITIALIZE_NAMELIST()
   mrp1 = mr + 1 
   npts_globe = nx_globe * ny_globe 
 
-  WRITE(message,*) & 
-       "nzm1, nzp1, npts, nvp1, nsp1, nzp1tmax, nsflxsm1, nsflxsp1, mrp1, npts_globe = ",  &
-       nzm1, nzp1, npts, nvp1, nsp1, nzp1tmax, nsflxsm1, nsflxsp2, mrp1, npts_globe
+  WRITE(message,*) "nzm1, nzp1, npts, nvp1, nsp1, nzp1tmax, nsflxsm1, nsflxsp1, mrp1, npts_globe = "
+  CALL mckpp_print(routine, message)
+  WRITE(message,*) nzm1, nzp1, npts, nvp1, nsp1, nzp1tmax, nsflxsm1, nsflxsp2, mrp1, npts_globe
   CALL mckpp_print(routine, message)
 
 #ifndef MCKPP_CAM3

--- a/mc-kpp_initialize_namelists.F90
+++ b/mc-kpp_initialize_namelists.F90
@@ -10,6 +10,7 @@ SUBROUTINE MCKPP_INITIALIZE_NAMELIST()
 #else
   USE mckpp_data_fields, ONLY: kpp_const_fields, mckpp_allocate_const_fields
 #endif
+  USE mckpp_log_messages, ONLY: mckpp_print, mckpp_print_error, max_message_len
   USE mckpp_namelists
   USE mckpp_parameters 
 
@@ -17,6 +18,8 @@ SUBROUTINE MCKPP_INITIALIZE_NAMELIST()
   
   ! Local variables    
   INTEGER :: i,j,k,l,ipt,ix,iy
+  CHARACTER(LEN=25) :: routine = "MCKPP_INITIALIZE_NAMELIST"
+  CHARACTER(LEN=max_message_len) :: message
  
   ! This is a bug fix for the IBM XLF compiler, which otherwise complains
   ! about "incorrect characters" in the namelist.  If you are using the
@@ -57,21 +60,21 @@ SUBROUTINE MCKPP_INITIALIZE_NAMELIST()
   ny_globe = 0.0
   
   READ(75,NAME_PARAMETERS) 
-  WRITE(nuout,*) 'KPP : Read Namelist PARAMETERS'
+  CALL mckpp_print(routine, "Read Namelist PARAMETERS") 
   IF ( (nx .LE. 0) .OR. (ny .LE. 0) .OR. (nz .LE. 0) ) THEN 
-    WRITE(nuerr,*) 'KPP : You must specify values of nx, ny and nz in the namelist'
+    CALL mckpp_print_error(routine, "You must specify values of nx, ny and nz in the namelist")
     CALL MCKPP_ABORT()
   END IF 
   IF (ngrid .LE. 0) THEN 
-    WRITE(nuerr,*) 'KPP : You must specify a value of ngrid in the namelist'
+    CALL mckpp_print_error(routine, "You must specify a value of ngrid in the namelist")
     CALL MCKPP_ABORT()
   END IF 
   IF (nztmax .LE. 0) THEN 
-    WRITE(nuerr,*) 'KPP : You must specify a value of nztmax in the namelist'
+    CALL mckpp_print_error(routine, "You must specify a value of nztmax in the namelist")
     CALL MCKPP_ABORT()
   END IF 
   IF ( (nx_globe .LE. 0) .OR. (ny_globe .LE. 0) ) THEN 
-    WRITE(nuerr,*) 'KPP : You must specify a value of nx_globe and ny_globe in the namelist'
+    CALL mckpp_print_error(routine, "You must specify a value of nx_globe and ny_globe in the namelist")
     CALL MCKPP_ABORT()
   END IF 
 
@@ -86,9 +89,10 @@ SUBROUTINE MCKPP_INITIALIZE_NAMELIST()
   mrp1 = mr + 1 
   npts_globe = nx_globe * ny_globe 
 
-  WRITE(nuout,*) &
+  WRITE(message,*) & 
        "nzm1, nzp1, npts, nvp1, nsp1, nzp1tmax, nsflxsm1, nsflxsp1, mrp1, npts_globe = ",  &
        nzm1, nzp1, npts, nvp1, nsp1, nzp1tmax, nsflxsm1, nsflxsp2, mrp1, npts_globe
+  CALL mckpp_print(routine, message)
 
 #ifndef MCKPP_CAM3
   CALL mckpp_allocate_const_fields() 
@@ -114,7 +118,7 @@ SUBROUTINE MCKPP_INITIALIZE_NAMELIST()
   FL=334000.                ! Latent heat of fusion for ice
   FLSN=FL                   ! Latent heat of fusion for snow
   READ(75,NAME_CONSTANTS)
-  WRITE(nuout,*) 'KPP : Read Namelist CONSTANTS'
+  CALL mckpp_print(routine, "Read Namelist CONSTANTS")
   
   ! Initialize and read the processes namelist
   LKPP=.TRUE.
@@ -127,7 +131,7 @@ SUBROUTINE MCKPP_INITIALIZE_NAMELIST()
   LRHS=.FALSE.
   L_SSref=.TRUE.
   READ(75,NAME_PROCSWIT)
-  WRITE(nuout,*) 'KPP : Read Namelist PROCSWIT'
+  CALL mckpp_print(routine, "Read Namelist PROCSWIT")
   
   ! Initilalize and read the location name list
   DMAX=0.0
@@ -141,15 +145,14 @@ SUBROUTINE MCKPP_INITIALIZE_NAMELIST()
   L_VGRID_FILE=.FALSE.
   READ(75,NAME_DOMAIN)
   IF (DMAX .LE. 0.0) THEN 
-     WRITE(nuerr,*) 'KPP : You must specify a depth for the domain'
+     CALL mckpp_print_error(routine, "You must specify a depth for the domain")
      CALL MCKPP_ABORT()
   ENDIF
   IF ((L_STRETCHGRID) .AND. (dscale .EQ. 0.0)) THEN
-     WRITE(nuerr,*) 'KPP : You cannot have dscale=0 for stretched ',&
-          'grids'
+     CALL mckpp_print_error(routine, "You cannot have dscale=0 for stretched grids") 
      CALL MCKPP_ABORT()
   ENDIF
-  write(nuout,*) 'KPP : Read Namelist DOMAIN'
+  CALL mckpp_print(routine, "Read Namelist DOMAIN")
   kpp_const_fields%alat=alat
   kpp_const_fields%alon=alon
   kpp_const_fields%delta_lat=delta_lat
@@ -159,7 +162,7 @@ SUBROUTINE MCKPP_INITIALIZE_NAMELIST()
   ! Initialize and read the landsea name list
   L_LANDSEA=.FALSE.
   READ(75,NAME_LANDSEA)
-  WRITE(nuout,*) 'KPP : Read Namelist LANDSEA'
+  CALL mckpp_print(routine, "Read Namelist LANDSEA")
   
   ! Initialize and read the start name list
   L_INITDATA= .TRUE.
@@ -167,7 +170,7 @@ SUBROUTINE MCKPP_INITIALIZE_NAMELIST()
   L_RESTART= .FALSE.
   WRITE(restart_infile,*) 'fort.30'
   READ(75,NAME_START) 
-  write(nuout,*) 'KPP : Read Namelist START'
+  CALL mckpp_print(routine, "Read Namelist START")
   
   ! Initialize and read the times namelist
   ndtocn=1
@@ -176,7 +179,7 @@ SUBROUTINE MCKPP_INITIALIZE_NAMELIST()
   finalt=-999.999
   READ(75,NAME_TIMES) 
   IF ((dtsec .LE. 0.0) .OR. (startt .LT. 0.0) .OR. (finalt .LT. 0.0)) THEN 
-     WRITE(nuerr,*) 'KPP : You must specify values of dtsec,startt,finalt in the namelist'
+     CALL mckpp_print_error(routine, "You must specify values of dtsec,startt,finalt in the namelist")
      CALL MCKPP_ABORT()
   ENDIF
   kpp_const_fields%ndtocn=ndtocn
@@ -189,16 +192,16 @@ SUBROUTINE MCKPP_INITIALIZE_NAMELIST()
   kpp_const_fields%nstart=nint(kpp_const_fields%startt)/kpp_const_fields%dto
   IF (float(kpp_const_fields%nend*kpp_const_fields%ndtocn) .NE. &
        (kpp_const_fields%finalt-kpp_const_fields%startt)/kpp_const_fields%dto) THEN
-     WRITE(nuerr,*) 'KPP : The integration length is not a multiple of the ocean timestep' 
-     WRITE(nuerr,*) 'dto=',kpp_const_fields%dto
-     WRITE(nuerr,*) 'finalt=',kpp_const_fields%finalt
-     WRITE(nuerr,*) 'startt=',kpp_const_fields%startt
+     CALL mckpp_print_error(routine, "The integration length is not a multiple of the ocean timestep")
+     WRITE(message, *) "dto = ", kpp_const_fields%dto, ", finalt = ", kpp_const_fields%finalt, &
+        ", startt = ", kpp_const_fields%startt
+     CALL mckpp_print_error(routine, message) 
      CALL MCKPP_ABORT()
   ENDIF
   kpp_const_fields%startt=kpp_const_fields%startt/kpp_const_fields%spd
   kpp_const_fields%finalt=kpp_const_fields%finalt/kpp_const_fields%spd
   kpp_const_fields%time=kpp_const_fields%startt
-  WRITE(nuout,*) 'KPP : Read Namelist TIMES'
+  CALL mckpp_print(routine, "Read Namelist TIMES") 
   
   ! Initialize and read the couple namelist
 #ifdef MCKPP_COUPLE
@@ -219,7 +222,7 @@ SUBROUTINE MCKPP_INITIALIZE_NAMELIST()
   jfirst=1
   jlast=ny
   READ(75,NAME_COUPLE)
-  write(nuout,*) 'KPP : Read Namelist COUPLE'
+  CALL mckpp_print(routine, "Read Namelist COUPLE")
   
   ! Initialize and read the advection namelist
   L_ADVECT=.FALSE.
@@ -263,28 +266,28 @@ SUBROUTINE MCKPP_INITIALIZE_NAMELIST()
   forcing_file='1D_ocean_forcing.nc'
   ocnT_file='none'
   READ(75,NAME_FORCING)
-  write(nuout,*) 'KPP : Read Namelist FORCING'    
+  CALL mckpp_print(routine, "Read Namelist FORCING")  
   IF (L_FCORR_WITHZ .AND. L_FCORR) THEN
-     WRITE(nuerr,*) 'KPP : L_FCORR and L_FCORR_WITHZ are '&
-          //'mutually exclusive.  Choose one or neither.'
+     WRITE(message, *) "L_FCORR and L_FCORR_WITHZ are mutually exclusive. Choose one or neither."
+     CALL mckpp_print_error(routine, message)
      CALL MCKPP_ABORT()
   ENDIF
   IF (L_SFCORR_WITHZ .AND. L_SFCORR) THEN
-     WRITE(nuerr,*) 'KPP : L_SFCORR and L_SFCORR_WITHZ are '&
-          //'mutually exclusive.  Choose one or neither.'
+     WRITE(message, *) "L_SFCORR and L_SFCORR_WITHZ are mutually exclusive. Choose one or neither."
+     CALL mckpp_print_error(routine, message)
      CALL MCKPP_ABORT()
   ENDIF
   IF (L_FCORR_WITHZ .AND. L_RELAX_SST) THEN
-     WRITE(nuerr,*) 'KPP : L_FCORR_WITHZ and L_RELAX_SST are '&
-          //'mutually exclusive.  Choose one or neither.'
+     WRITE(message, *) "L_FCORR_WITHZ and L_RELAX_SST are mutually exclusive. Choose one or neither."
+     CALL mckpp_print_error(routine, message)
      CALL MCKPP_ABORT()
   ENDIF
   IF (L_NO_ISOTHERM .AND. (ocnT_file .eq. 'none' .or.&
-       sal_file .eq. 'none')) THEN
-     WRITE(nuerr,*) 'KPP : If you specify L_NO_ISOTHERM for '&
-          //'reseting of isothermal points, you must specify files '&
-          //'from which to read climatological ocean temperature '&
-          //'(ocnT_file) and salinity (sal_file).'
+      sal_file .eq. 'none')) THEN
+     WRITE(message, *) "If you specify L_NO_ISOTHERM for reseting of isothermal points, " &
+        // "you must specify files from which to read climatological ocean temperature " &
+        // "(ocnT_file) and salinity (sal_file)."
+     CALL mckpp_print_error(routine, message)
      CALL MCKPP_ABORT()
   ELSEIF (L_NO_ISOTHERM) THEN
      kpp_const_fields%iso_bot=isotherm_bottom
@@ -297,7 +300,7 @@ SUBROUTINE MCKPP_INITIALIZE_NAMELIST()
   L_RESTARTW=.TRUE.      
   kpp_const_fields%ndt_per_restart=kpp_const_fields%nend*kpp_const_fields%ndtocn    
     READ(75,NAME_OUTPUT)
-  write(nuout,*) 'Read Namelist OUTPUT'    
+  CALL mckpp_print(routine, "Read Namelist OUTPUT") 
   
   ! Call routine to copy constants and logicals needed for ocean
   ! physics into the kpp_const_fields derived type.  Added for 

--- a/mc-kpp_initialize_relaxation.F90
+++ b/mc-kpp_initialize_relaxation.F90
@@ -14,7 +14,8 @@ SUBROUTINE MCKPP_INITIALIZE_RELAXATION()
 #else
   USE mckpp_data_fields, ONLY: kpp_3d_fields, kpp_const_fields
 #endif
-  USE mckpp_parameters, ONLY: nx, ny, ny_globe, nuout
+  USE mckpp_log_messages, ONLY: mckpp_print, max_message_len
+  USE mckpp_parameters, ONLY: nx, ny, ny_globe
 
 ! Re-write logic to allow for relaxing either SST or
 ! salinity - NPK 24/08/11
@@ -27,7 +28,8 @@ SUBROUTINE MCKPP_INITIALIZE_RELAXATION()
 #endif
  
   INTEGER ix,iy,ipoint,my_ny
-  
+   CHARACTER(LEN=27) :: routine = "MCKPP_INITIALIZE_RELAXATION"
+ 
 !  REAL sst_in(NX_GLOBE,NY_GLOBE,1)
 !  COMMON /save_sstin/ sst_in
 
@@ -146,6 +148,6 @@ SUBROUTINE MCKPP_INITIALIZE_RELAXATION()
      ENDDO
   ENDDO
   
-  write(nuout,*) 'MCKPP_INITIALIZE_RELAXATION: Calculated SST0, fcorr and scorr'
+  CALL mckpp_print(routine, "Calculated SST0, fcorr and scorr")
 
 END SUBROUTINE mckpp_initialize_relaxation

--- a/mc-kpp_initialize_relaxation.F90
+++ b/mc-kpp_initialize_relaxation.F90
@@ -86,7 +86,8 @@ SUBROUTINE MCKPP_INITIALIZE_RELAXATION()
         ELSE
 #ifdef MCKPP_CAM3
            IF (masterproc) THEN
-              WRITE(6,*) iy,kpp_const_fields%relax_sal_in(iy)
+              WRITE(message,*) iy,kpp_const_fields%relax_sal_in(iy)
+              CALL mckpp_print(routine, message)
               kpp_global_fields%relax(:,iy)=1./(kpp_const_fields%relax_sal_in(iy)*kpp_const_fields%spd)           
            ENDIF
 #else

--- a/mc-kpp_log_messages.F90
+++ b/mc-kpp_log_messages.F90
@@ -31,7 +31,7 @@ CONTAINS
     CHARACTER(LEN=*), INTENT(IN) :: routine, message
     CHARACTER(LEN=max_print_len) :: print_message
     
-    print_message = TRIM(routine) // ": " // TRIM(message)
+    print_message = TRIM(routine) // ": " // TRIM(ADJUSTL(message))
     CALL mckpp_write(nuout, print_message) 
     
   END SUBROUTINE mckpp_print
@@ -74,9 +74,9 @@ CONTAINS
     CHARACTER(LEN=*) :: string
 
 #ifdef MCKPP_CAM3
-    IF (masterproc) THEN WRITE(unit,*) TRIM(string)
+    IF (masterproc) THEN WRITE(unit,*) TRIM(ADJUSTL(string))
 #else
-    WRITE(unit,*) TRIM(string)
+    WRITE(unit,*) TRIM(ADJUSTL(string))
 #endif
 
   END SUBROUTINE mckpp_write

--- a/mc-kpp_log_messages.F90
+++ b/mc-kpp_log_messages.F90
@@ -74,9 +74,9 @@ CONTAINS
     CHARACTER(LEN=*) :: string
 
 #ifdef MCKPP_CAM3
-    IF (masterproc) THEN WRITE(unit,*) string
+    IF (masterproc) THEN WRITE(unit,*) TRIM(string)
 #else
-    WRITE(unit,*) string
+    WRITE(unit,*) TRIM(string)
 #endif
 
   END SUBROUTINE mckpp_write

--- a/mc-kpp_log_messages.F90
+++ b/mc-kpp_log_messages.F90
@@ -1,0 +1,83 @@
+! Routines to print log messages to stdout, and error/warnings to 
+! stderr. If running in parallel (CAM) only masterproc writes messages.
+! 
+! Ideas:
+! - flags to control the level of prints
+! - flag to flush output after each write
+! - support to redirect messages to file
+
+MODULE mckpp_log_messages
+
+#ifdef MCKPP_CAM3
+  USE pmgrid, only: masterproc
+#endif  
+ 
+  IMPLICIT NONE 
+
+  PUBLIC :: mckpp_print_log, mckpp_print_error, mckpp_print_warning
+  PUBLIC :: max_message_len
+
+  PRIVATE
+  
+  INTEGER :: nuout = 6,  nuerr = 0
+  INTEGER, PARAMETER :: max_message_len = 100, max_print_len = 150
+
+CONTAINS
+
+  ! Write to stdout
+  SUBROUTINE mckpp_print_log(routine, message)
+
+    CHARACTER(LEN=*), INTENT(IN) :: routine, message
+    CHARACTER(LEN=max_print_len) :: print_message
+    
+    print_message = TRIM(routine) // ": " // TRIM(message)
+    CALL mckpp_print(nuout, print_message) 
+    
+  END SUBROUTINE mckpp_print_log
+
+
+  ! Write error to stderr, split over 2 lines 
+  SUBROUTINE mckpp_print_error(routine, message)
+    
+    CHARACTER(LEN=*), INTENT(IN) :: routine, message
+    CHARACTER(LEN=max_print_len) :: print_message
+
+    print_message = "Error in " // TRIM(routine) // ":"
+    CALL mckpp_print(nuerr, print_message)
+    
+    print_message = message
+    CALL mckpp_print(nuerr, print_message)
+    
+  END SUBROUTINE mckpp_print_error
+
+
+  ! Write warning to stderr, split over 2 lines 
+  SUBROUTINE mckpp_print_warning(routine, message)
+    
+    CHARACTER(LEN=*), INTENT(IN) :: routine, message
+    CHARACTER(LEN=max_print_len) :: print_message
+
+    print_message = "Warning in " // TRIM(routine) // ":"
+    CALL mckpp_print(nuerr, print_message)
+    
+    print_message = message
+    CALL mckpp_print(nuerr, print_message)
+    
+  END SUBROUTINE mckpp_print_warning
+  
+
+  ! Internal : call write
+  SUBROUTINE mckpp_print(unit, string)
+
+    INTEGER, INTENT(IN) :: unit
+    CHARACTER(LEN=*) :: string
+
+#ifdef MCKPP_CAM3
+    IF (masterproc) THEN WRITE(unit,*) string
+#else
+    WRITE(unit,*) string
+#endif
+
+  END SUBROUTINE mckpp_print 
+  
+END MODULE mckpp_log_messages 

--- a/mc-kpp_log_messages.F90
+++ b/mc-kpp_log_messages.F90
@@ -14,7 +14,7 @@ MODULE mckpp_log_messages
  
   IMPLICIT NONE 
 
-  PUBLIC :: mckpp_print_log, mckpp_print_error, mckpp_print_warning
+  PUBLIC :: mckpp_print, mckpp_print_error, mckpp_print_warning
   PUBLIC :: max_message_len
 
   PRIVATE
@@ -25,15 +25,15 @@ MODULE mckpp_log_messages
 CONTAINS
 
   ! Write to stdout
-  SUBROUTINE mckpp_print_log(routine, message)
+  SUBROUTINE mckpp_print(routine, message)
 
     CHARACTER(LEN=*), INTENT(IN) :: routine, message
     CHARACTER(LEN=max_print_len) :: print_message
     
     print_message = TRIM(routine) // ": " // TRIM(message)
-    CALL mckpp_print(nuout, print_message) 
+    CALL mckpp_write(nuout, print_message) 
     
-  END SUBROUTINE mckpp_print_log
+  END SUBROUTINE mckpp_print
 
 
   ! Write error to stderr, split over 2 lines 
@@ -43,10 +43,10 @@ CONTAINS
     CHARACTER(LEN=max_print_len) :: print_message
 
     print_message = "Error in " // TRIM(routine) // ":"
-    CALL mckpp_print(nuerr, print_message)
+    CALL mckpp_write(nuerr, print_message)
     
     print_message = message
-    CALL mckpp_print(nuerr, print_message)
+    CALL mckpp_write(nuerr, print_message)
     
   END SUBROUTINE mckpp_print_error
 
@@ -58,16 +58,16 @@ CONTAINS
     CHARACTER(LEN=max_print_len) :: print_message
 
     print_message = "Warning in " // TRIM(routine) // ":"
-    CALL mckpp_print(nuerr, print_message)
+    CALL mckpp_write(nuerr, print_message)
     
     print_message = message
-    CALL mckpp_print(nuerr, print_message)
+    CALL mckpp_write(nuerr, print_message)
     
   END SUBROUTINE mckpp_print_warning
   
 
   ! Internal : call write
-  SUBROUTINE mckpp_print(unit, string)
+  SUBROUTINE mckpp_write(unit, string)
 
     INTEGER, INTENT(IN) :: unit
     CHARACTER(LEN=*) :: string
@@ -78,6 +78,6 @@ CONTAINS
     WRITE(unit,*) string
 #endif
 
-  END SUBROUTINE mckpp_print 
+  END SUBROUTINE mckpp_write
   
 END MODULE mckpp_log_messages 

--- a/mc-kpp_log_messages.F90
+++ b/mc-kpp_log_messages.F90
@@ -2,6 +2,7 @@
 ! stderr. If running in parallel (CAM) only masterproc writes messages.
 ! 
 ! Ideas:
+! - split long messages over multiple lines
 ! - flags to control the level of prints
 ! - flag to flush output after each write
 ! - support to redirect messages to file
@@ -20,7 +21,7 @@ MODULE mckpp_log_messages
   PRIVATE
   
   INTEGER :: nuout = 6,  nuerr = 0
-  INTEGER, PARAMETER :: max_message_len = 100, max_print_len = 150
+  INTEGER, PARAMETER :: max_message_len = 150, max_print_len = 200
 
 CONTAINS
 

--- a/mc-kpp_ocean_model_3D.F90
+++ b/mc-kpp_ocean_model_3D.F90
@@ -1,6 +1,7 @@
 PROGRAM mckpp_ocean_model_3d
 
 USE mckpp_data_fields, ONLY: kpp_3d_fields, kpp_const_fields
+USE mckpp_log_messages, ONLY: mckpp_print, max_message_len
 USE mckpp_timer, ONLY: mckpp_initialize_timers, mckpp_start_timer, &
     mckpp_stop_timer, mckpp_print_timers
 USE mckpp_xios_control, ONLY: mckpp_initialize_output, mckpp_output_control, &
@@ -8,11 +9,12 @@ USE mckpp_xios_control, ONLY: mckpp_initialize_output, mckpp_output_control, &
 
 IMPLICIT NONE
 
-
   INTEGER :: ntime
+  CHARACTER(LEN=20) :: routine = "MCKPP_OCEAN_MODEL_3D"
+  CHARACTER(LEN=max_message_len) :: message
   
   ! Initialise
-  WRITE(6,*) "MCKPP_OCEAN_MODEL_3D: Initialisation"
+  CALL mckpp_print(routine, "Initialisation")
 
   CALL mckpp_initialize_timers()
   CALL mckpp_start_timer('Initialization')
@@ -24,13 +26,14 @@ IMPLICIT NONE
   CALL mckpp_stop_timer('Initialization')
 
   ! Main time-stepping loop
-  WRITE(6,*) "MCKPP_OCEAN_MODEL_3D: Timestepping loop"
+  CALL mckpp_print(routine, "Timestepping loop")
 
   DO ntime = 1, kpp_const_fields%nend*kpp_const_fields%ndtocn
      kpp_const_fields%ntime = ntime
      kpp_const_fields%time = kpp_const_fields%startt+(kpp_const_fields%ntime-1)*&
        kpp_const_fields%dto/kpp_const_fields%spd
-     WRITE(6,*) "ntime, time = ", kpp_const_fields%ntime, kpp_const_fields%time
+     WRITE(message,*) "ntime, time = ", kpp_const_fields%ntime, kpp_const_fields%time
+     CALL mckpp_print(routine, message)
 
      ! Fluxes
      IF (MOD(kpp_const_fields%ntime-1,kpp_const_fields%ndtocn) .EQ. 0) THEN
@@ -62,7 +65,7 @@ IMPLICIT NONE
   END DO
 
   ! Finalise
-  WRITE(6,*) "MCKPP_OCEAN_MODEL_3D: Finalisation"
+  CALL mckpp_print(routine, "Finalisation")
   CALL mckpp_finalize_output() 
   CALL mckpp_print_timers()
 

--- a/mc-kpp_parameters.F90
+++ b/mc-kpp_parameters.F90
@@ -2,8 +2,7 @@ MODULE mckpp_parameters
 
   INTEGER, PARAMETER :: & 
        max_nc_filename_len = 50, &
-       max_restart_filename_len = 50, & 
-       max_error_msg_len = 100
+       max_restart_filename_len = 50
 
   ! These are read in from parameters namelist
   INTEGER :: & 

--- a/mc-kpp_parameters.F90
+++ b/mc-kpp_parameters.F90
@@ -5,10 +5,6 @@ MODULE mckpp_parameters
        max_restart_filename_len = 50, & 
        max_error_msg_len = 100
 
-  INTEGER, PARAMETER :: & 
-       nuout = 6, & 
-       nuerr = 0
-
   ! These are read in from parameters namelist
   INTEGER :: & 
 

--- a/mc-kpp_physics_driver.F90
+++ b/mc-kpp_physics_driver.F90
@@ -32,7 +32,6 @@ SUBROUTINE mckpp_physics_driver()
   CHARACTER(LEN=19) trans_timer_name
   
 #ifdef MCKPP_CAM3
-  !WRITE(6,*) 'Before ocnstep, U = ',kpp_3d_fields(begchunk)%U(1:ncol,1,1)
   DO ichnk=begchunk,endchunk
      ncol=get_ncols_p(ichnk)
      DO icol=1,ncol
@@ -45,7 +44,6 @@ SUBROUTINE mckpp_physics_driver()
         ENDIF
      ENDDO
   ENDDO   
-  !WRITE(6,*) 'After ocnstep, U = ',kpp_3d_fields(begchunk)%U(1:ncol,1,1)
 #else
 #ifdef OPENMP
 !$OMP PARALLEL DEFAULT(NONE) &

--- a/mc-kpp_physics_ocnstep.F90
+++ b/mc-kpp_physics_ocnstep.F90
@@ -5,7 +5,7 @@ SUBROUTINE mckpp_physics_ocnstep(kpp_1d_fields,kpp_const_fields)
 #else
   USE mckpp_data_fields, ONLY: kpp_1d_type, kpp_const_type
 #endif
-  USE mckpp_log_messages, ONLY: mckpp_print, max_message_len
+  USE mckpp_log_messages, ONLY: mckpp_print, mckpp_print_warning, max_message_len
   USE mckpp_parameters, ONLY: nz, nzp1, nvel, nsclr, nsp1, hmixtolfrac, itermax
   
   !-----------------------------------------------------------------------
@@ -90,12 +90,12 @@ SUBROUTINE mckpp_physics_ocnstep(kpp_1d_fields,kpp_const_fields)
         DO l=1,NVEL
            IF (kpp_1d_fields%old .lt. 0 .or. kpp_1d_fields%old .gt. 1) THEN
               WRITE(message,*) 'Dodgy value of old at k=',k,'l=',l,'old=',kpp_1d_fields%old
-              CALL write_print_warning(routine, message)
+              CALL mckpp_print_warning(routine, message)
               kpp_1d_fields%old=kpp_1d_fields%new
            ENDIF
            IF (kpp_1d_fields%new .lt. 0 .or. kpp_1d_fields%new .gt. 1) THEN
               WRITE(message,*) 'Dodgy value of new at k=',k,'l=',l,'new=',kpp_1d_fields%new
-              CALL write_print_warning(routine, message)
+              CALL mckpp_print_warning(routine, message)
               kpp_1d_fields%new=kpp_1d_fields%old
            ENDIF        
            kpp_1d_fields%U(k,l)=2.*kpp_1d_fields%Us(k,l,kpp_1d_fields%new)- &

--- a/mc-kpp_physics_overrides.F90
+++ b/mc-kpp_physics_overrides.F90
@@ -87,7 +87,8 @@ SUBROUTINE mckpp_physics_overrides_check_profile(kpp_1d_fields,kpp_const_fields)
 #else 
   USE mckpp_data_fields, ONLY: kpp_1d_type,kpp_const_type
 #endif
-  USE mckpp_parameters, ONLY: nuout, nzp1
+  USE mckpp_log_messages, ONLY: mckpp_print_warning, max_message_len
+  USE mckpp_parameters, ONLY: nzp1
 
   IMPLICIT NONE
 
@@ -96,6 +97,9 @@ SUBROUTINE mckpp_physics_overrides_check_profile(kpp_1d_fields,kpp_const_fields)
 
   INTEGER :: z,j
   REAL :: dz_total,dtdz_total,dz
+  
+  CHARACTER(LEN=36) :: routine = "MCKPP_PHSYICS_OVERRIDE_CHECK_PROFILE"
+  CHARACTER(LEN=max_message_len) :: message
 
   ! If the integration has failed because of unrealistic values in T, S, U or V
   ! or very high RMS difference between the old and new profiles, then reset
@@ -103,18 +107,23 @@ SUBROUTINE mckpp_physics_overrides_check_profile(kpp_1d_fields,kpp_const_fields)
   ! NPK 17/5/13.
   IF (kpp_1d_fields%comp_flag .and. kpp_const_fields%ocnT_file .ne. 'none' .and. &
        kpp_const_fields%sal_file .ne. 'none') THEN
-     WRITE(nuout,*) 'Resetting point to climatology ...'
+     CALL mckpp_print_warning(routine, "Resetting point to climatology.")
      kpp_1d_fields%X(:,1)=kpp_1d_fields%ocnT_clim(:)
-     !WRITE(nuout,*) 'T = ',kpp_1d_fields%ocnT_clim(:)
+     ! WRITE(message,*) 'T = ',kpp_1d_fields%ocnT_clim(:)
+     ! CALL mckpp_print_warning(routine, message)
      kpp_1d_fields%X(:,2)=kpp_1d_fields%sal_clim(:)
-     !WRITE(nuout,*) 'S = ',kpp_1d_fields%sal_clim(:)
+     ! WRITE(message,*) 'S = ',kpp_1d_fields%sal_clim(:)
+     ! CALL mckpp_print_warning(routine, message)
      kpp_1d_fields%U=kpp_1d_fields%U_init(:,:)
-     !WRITE(nuout,*) 'U = ',kpp_1d_fields%U_init(:,1)
-     !WRITE(nuout,*) 'V = ',kpp_1d_fields%U_init(:,2)
+     ! WRITE(message,*) 'U = ',kpp_1d_fields%U_init(:,1)
+     ! CALL mckpp_print_warning(routine, message)
+     ! WRITE(message,*) 'V = ',kpp_1d_fields%U_init(:,2)
+     ! CALL mckpp_print_warning(routine, message)
      kpp_1d_fields%reset_flag=999
   ELSE IF (kpp_1d_fields%comp_flag) THEN
-     WRITE(nuout,*) 'Cannot reset point to T,S climatology as either ocean temperature or salinity data '//&
+     WRITE(message,*) 'Cannot reset point to T,S climatology as either ocean temperature or salinity data '//&
           'not provided.  Will reset currents to initial conditions and keep going.'
+     CALL mckpp_print_warning(routine, message)
      kpp_1d_fields%U=kpp_1d_fields%U_init(:,:)
      kpp_1d_fields%reset_flag=999
   ENDIF

--- a/mc-kpp_physics_solvers.F90
+++ b/mc-kpp_physics_solvers.F90
@@ -238,9 +238,9 @@ subroutine mckpp_physics_solvers_rhsmod(jsclr,mode,A,dto,km,dm,nzi,rhs,kpp_1d_fi
 !        day = time - dpy * (idint(time/dpy))  ! 365.25))
 !        month = 1 + int(12. * day / dpy)    ! 367.)
 !        if(month.gt.12) then
-!           write(nuerr,*) 'STOP rhsmod (ocn.f):'
-!           write(nuerr,*) '     rounding error, month gt 12 =',month
-!           stop 97
+!           WRITE(message,*) 'Rounding error, month gt 12 =',month
+!           CALL mckpp_print_error(routine, message) 
+!           CALL mckpp_abort()
 !        endif
 
 !       Am = -12. * f(month) * (xsA(iyr) - 0.0 )       ! Annual
@@ -307,9 +307,9 @@ subroutine mckpp_physics_solvers_rhsmod(jsclr,mode,A,dto,km,dm,nzi,rhs,kpp_1d_fi
      !     month = 1 + int(12. * day / dpy)    ! 367.)
      !     diag
      !     if(month.gt.12) then
-     !     write(nuerr,*) 'STOP rhsmod (ocn.f):'
-     !     write(nuerr,*) '     rounding error, month gt 12 =',month
-     !     stop 97
+     !     WRITE(message,*) 'Rounding error, month gt 12 =',month
+     !     CALL mckpp_print_error(routine, message) 
+     !     CALL mckpp_abort()
      !     endif  
      !     diag
      !     Am = -12. * f(month) * (xsA(iyr) - 0.0 )       ! Annual

--- a/mc-kpp_physics_solvers.F90
+++ b/mc-kpp_physics_solvers.F90
@@ -344,7 +344,7 @@ subroutine mckpp_physics_solvers_rhsmod(jsclr,mode,A,dto,km,dm,nzi,rhs,kpp_1d_fi
 706     continue
         
      else
-        WRITE(message,*) 'STOP in rhsmod (ocn.f): mode out of range, mode = ', mode
+        WRITE(message,*) 'mode out of range, mode = ', mode
         CALL mckpp_print_error(routine, message)
         CALL MCKPP_ABORT()
      endif

--- a/mc-kpp_physics_solvers.F90
+++ b/mc-kpp_physics_solvers.F90
@@ -121,7 +121,8 @@ END SUBROUTINE mckpp_physics_solvers_tridrhs
 
 SUBROUTINE mckpp_physics_solvers_tridmat(cu,cc,cl,rhs,yo,nzi,yn)
 
-  USE mckpp_parameters, ONLY: nztmax, nuerr
+  USE mckpp_log_messages, ONLY: mckpp_print_error, max_message_len
+  USE mckpp_parameters, ONLY: nztmax
 
   ! Solve tridiagonal matrix for new vector yn, given right hand side
   ! vector rhs. Note: yn(nzi+1) = yo(nzi+1).
@@ -144,6 +145,9 @@ SUBROUTINE mckpp_physics_solvers_tridmat(cu,cc,cl,rhs,yo,nzi,yn)
   ! more local for implicit none
   integer i
 
+  CHARACTER(LEN=26) :: routine = "MCKPP_PHSYICS_SOLVER_TRIDMAT"
+  CHARACTER(LEN=max_message_len) :: message
+  
   ! Solve tridiagonal matrix.
   bet   = cc(1)
   yn(1) =  rhs(1) / bet    ! surface
@@ -151,10 +155,13 @@ SUBROUTINE mckpp_physics_solvers_tridmat(cu,cc,cl,rhs,yo,nzi,yn)
      gam(i)= cl(i-1)/bet
      bet   = cc(i) - cu(i)*gam(i)
      if(bet.eq.0.) then
-        write(nuerr,*)'* algorithm for solving tridiag matrix fails'
-        write(nuerr,*)'* bet=',bet
-        write(nuerr,*)'*i-1=',i-1,' cc=',cc(i-1),'cl=',cl(i-1)
-        write(nuerr,*)'*i=',i,' cc=',cc(i),' cu=',cu(i),' gam=',gam(i)
+        CALL mckpp_print_error(routine, "Algorithm for solving tridiag matrix failed.")
+        WRITE(message,*) 'bet = ', bet
+        CALL mckpp_print_error(routine, message) 
+        WRITE(message,*) 'i-1 = ', i-1, ', cc = ', cc(i-1), ', cl = ', cl(i-1)
+        CALL mckpp_print_error(routine, message) 
+        WRITE(message,*) 'i = ', i, ', cc = ', cc(i), ', cu=', cu(i), ', gam = ', gam(i)
+        CALL mckpp_print_error(routine, message) 
         CALL MCKPP_ABORT()
         bet=1.E-12
         !     Pause 3
@@ -178,7 +185,7 @@ subroutine mckpp_physics_solvers_rhsmod(jsclr,mode,A,dto,km,dm,nzi,rhs,kpp_1d_fi
 #else
   USE mckpp_data_fields, ONLY: kpp_1d_type,kpp_const_type
 #endif
-  USE mckpp_parameters, ONLY: nuerr
+  USE mckpp_log_messages, ONLY: mckpp_print_error, max_message_len
 
 !     Modify rhs to correct scalar, jsclr, 
 !     for advection according to mode
@@ -214,6 +221,9 @@ subroutine mckpp_physics_solvers_rhsmod(jsclr,mode,A,dto,km,dm,nzi,rhs,kpp_1d_fi
   ! Internal
   real f(12)     ! monthly partion of annual advection
   real xsA(21)   ! yearly excess of heat
+
+  CHARACTER(LEN=27) :: routine = "MCKPP_PHSYICS_SOLVER_RHSMOD"
+  CHARACTER(LEN=max_message_len) :: message
 
   !data f/.1,.1,6*0.0,.1,.3,.4,.2/
   f = (/.05, .05, 0.0, 0.0, 0.0, 0.0, 0.0, .05, .15, .20, &
@@ -334,8 +344,8 @@ subroutine mckpp_physics_solvers_rhsmod(jsclr,mode,A,dto,km,dm,nzi,rhs,kpp_1d_fi
 706     continue
         
      else
-        write(nuerr,*) 'STOP in rhsmod (ocn.f):'
-        write(nuerr,*) '      mode out of range, mode=',mode
+        WRITE(message,*) 'STOP in rhsmod (ocn.f): mode out of range, mode = ', mode
+        CALL mckpp_print_error(routine, message)
         CALL MCKPP_ABORT()
      endif
      

--- a/mc-kpp_read_fluxes.F90
+++ b/mc-kpp_read_fluxes.F90
@@ -16,7 +16,7 @@ SUBROUTINE MCKPP_READ_FLUXES(taux, tauy, swf, lwf, lhf, shf, rain, snow)
   INTEGER :: status, flx_ncid, time_varid
   INTEGER, DIMENSION(3) :: count, start
 
-  CHARACTER(LEN=27) :: routine = "MCKPP_READ_FLUXES"
+  CHARACTER(LEN=17) :: routine = "MCKPP_READ_FLUXES"
   CHARACTER(LEN=max_message_len) :: message
 
   status=NF_OPEN(kpp_const_fields%forcing_file,0,flx_ncid)

--- a/mc-kpp_read_heatcorrections.F90
+++ b/mc-kpp_read_heatcorrections.F90
@@ -14,7 +14,8 @@ SUBROUTINE MCKPP_READ_FCORR_2D()
 #else
   USE mckpp_data_fields, ONLY: kpp_3d_fields, kpp_const_fields
 #endif
-  USE mckpp_parameters, ONLY: nx, ny, nx_globe, ny_globe, nzp1, nuout, nuerr
+  USE mckpp_log_messages, ONLY: mckpp_print, mckpp_print_error, max_message_len
+  USE mckpp_parameters, ONLY: nx, ny, nx_globe, ny_globe, nzp1
 
   IMPLICIT NONE
   INTEGER start(3),count(3)
@@ -32,6 +33,9 @@ SUBROUTINE MCKPP_READ_FCORR_2D()
   REAL*4 ixx,jyy,first_timein,time_in,ndays_upd_fcorr,last_timein
   REAL*4, ALLOCATABLE :: fcorr_twod_in(:,:,:), latitudes(:), longitudes(:), z(:)
   CHARACTER(LEN=30) tmp_name
+
+  CHARACTER(LEN=19) :: routine = "MCKPP_READ_FCORR_2D"
+  CHARACTER(LEN=max_message_len) :: message
   
   ! Read in a NetCDF file containing a time-varying flux correction
   ! at the surface only.  Frequency of read is controlled by ndtupdfcorr
@@ -62,16 +66,16 @@ SUBROUTINE MCKPP_READ_FCORR_2D()
   count(:)=(/my_nx,my_ny,1/)
 
 #ifdef MCKPP_CAM3  
-  !WRITE(6,*) 'MCKPP_READ_FCORR_2D: Calling MCKPP_DETERMINE_NETCDF_BOUNDARIES'    
+  ! CALL mckpp_print(routine, "Calling MCKPP_DETERMINE_NETCDF_BOUNDARIES") 
   CALL MCKPP_DETERMINE_NETCDF_BOUNDARIES(fcorr_ncid,'flux correction','latitude','longitude',&
        't',kpp_global_fields%longitude(1),kpp_global_fields%latitude(1),start(1),start(2),&
        first_timein,last_timein,time_varid)
-  !WRITE(6,*) 'MCKPP_READ_FCORR_2D: Returned from MCKPP_DETERMINE_NETCDF_BOUNDARIES'
+  ! CALL mckpp_print(routine, "Returned from MCKPP_DETERMINE_NETCDF_BOUNDARIES") 
 #else
-  !WRITE(6,*) 'MCKPP_READ_FCORR_2D: Calling MCKPP_DETERMINE_NETCDF_BOUNDARIES'    
+  ! CALL mckpp_print(routine, "Calling MCKPP_DETERMINE_NETCDF_BOUNDARIES") 
   CALL MCKPP_DETERMINE_NETCDF_BOUNDARIES(fcorr_ncid,'flux correction','latitude','longitude',&
        't',kpp_3d_fields%dlon(1),kpp_3d_fields%dlat(1),start(1),start(2),first_timein,last_timein,time_varid)  
-  !WRITE(6,*) 'MCKPP_READ_FCORR_2D: Returned from MCKPP_DETERMINE_NETCDF_BOUNDARIES'
+  ! CALL mckpp_print(routine, "Returned from MCKPP_DETERMINE_NETCDF_BOUNDARIES") 
 #endif
 
   status=NF_INQ_VARID(fcorr_ncid,'fcorr',fcorr_varid)
@@ -88,22 +92,27 @@ SUBROUTINE MCKPP_READ_FCORR_2D()
            fcorr_time=fcorr_time-kpp_const_fields%fcorr_period
         ENDDO
      ELSE
-        WRITE(nuout,*) 'MCKPP_READ_FCORR_2D: &
-             & Time for which to read the flux corrections exceeds the last time in the netCDF file &
-             & and L_PERIODIC_FCORR has not been specified. Attempting to read flux corrections will lead to &
-             & an error, so aborting now ...'
+        WRITE(message,*) "Time for which to read the flux corrections exceeds the last time ", &
+           "in the netCDF file and L_PERIODIC_FCORR has not been specified. "
+        CALL mckpp_print_error(routine, message) 
+        WRITE(message,*) "Attempting to read flux corrections will lead to an error, ", &
+           "so aborting now ..."
+        CALL mckpp_print_error(routine, message) 
         CALL MCKPP_ABORT()
      ENDIF
   ENDIF
 
-  write(nuout,*) 'MCKPP_READ_FCORR_2D: Reading flux correction for time ',fcorr_time
+  WRITE(message,*) 'Reading flux correction for time ',fcorr_time
+  CALL mckpp_print(routine, message)
   start(3)=NINT((fcorr_time-first_timein)*kpp_const_fields%spd/(kpp_const_fields%dto*kpp_const_fields%ndtupdfcorr))+1  
   status=NF_GET_VAR1_REAL(fcorr_ncid,time_varid,start(3),time_in)
   
   IF (status .NE. NF_NOERR) CALL MCKPP_HANDLE_ERR(status)
   IF (abs(time_in-fcorr_time) .GT. 0.03*kpp_const_fields%dtsec/kpp_const_fields%spd) THEN
-     write(nuerr,*) 'MCKPP_READ_FCORR_2D: Cannot find time',fcorr_time,'in flux-correction input file'
-     write(nuerr,*) 'MCKPP_READ_FCORR_2D: The closest I came was',time_in
+     WRITE(message,*) 'Cannot find time',fcorr_time,'in flux-correction input file'
+     CALL mckpp_print_error(routine, message) 
+     WRITE(message,*) 'The closest I came was',time_in
+     CALL mckpp_print_error(routine, message) 
      CALL MCKPP_ABORT
   ENDIF
   status=NF_GET_VARA_REAL(fcorr_ncid,fcorr_varid,start,count,fcorr_twod_in)
@@ -142,7 +151,8 @@ SUBROUTINE MCKPP_READ_FCORR_3D()
 #else
   USE mckpp_data_fields, ONLY: kpp_3d_fields, kpp_const_fields
 #endif
-  USE mckpp_parameters, ONLY: nx, ny, nx_globe, ny_globe, nzp1, nuout, nuerr
+  USE mckpp_log_messages, ONLY: mckpp_print, mckpp_print_error, max_message_len
+  USE mckpp_parameters, ONLY: nx, ny, nx_globe, ny_globe, nzp1
   
   IMPLICIT NONE
 #include <netcdf.inc>
@@ -160,6 +170,9 @@ SUBROUTINE MCKPP_READ_FCORR_3D()
   REAL*4 ixx,jyy,first_timein,time_in,ndays_upd_fcorr,last_timein
   CHARACTER(LEN=30) tmp_name
   REAL*4, allocatable :: fcorr_in(:,:,:,:),longitudes(:),latitudes(:),z(:)
+  
+  CHARACTER(LEN=19) :: routine = "MCKPP_READ_FCORR_3D"
+  CHARACTER(LEN=max_message_len) :: message
   
   ! Read in a NetCDF file containing a 
   ! time-varying flux correction at every model vertical level.
@@ -196,9 +209,11 @@ SUBROUTINE MCKPP_READ_FCORR_3D()
   status=NF_INQ_DIM(fcorr_ncid,z_dimid,tmp_name,nz_file)
   IF (status .NE. NF_NOERR) CALL MCKPP_HANDLE_ERR(status)
   IF (NZP1.ne.nz_file) THEN
-     WRITE(nuerr,*) 'MCKPP_READ_FCORR_3D: Input file for flux corrections does &
-          & not have the correct number of vertical levels. ',&
-          'It should have ',NZP1,' but instead has ',nz_file
+     WRITE(message,*) "Input file for flux corrections does not have the correct ", &
+         "number of vertical levels."
+     CALL mckpp_print_error(routine, message)
+     WRITE(message,*) "It should have ", NZP1, " but instead has ", nz_file
+     CALL mckpp_print_error(routine, message)
      CALL MCKPP_ABORT
   ELSE
      status=NF_GET_VAR_REAL(fcorr_ncid,z_varid,z)
@@ -206,25 +221,26 @@ SUBROUTINE MCKPP_READ_FCORR_3D()
   ENDIF
   
 #ifdef MCKPP_CAM3  
-  !WRITE(nuout,*) 'MCKPP_READ_FCORR_3D: Calling MCKPP_DETERMINE_NETCDF_BOUNDARIES'    
+  ! CALL mckpp_print(routine, "Calling MCKPP_DETERMINE_NETCDF_BOUNDARIES")
   CALL MCKPP_DETERMINE_NETCDF_BOUNDARIES(fcorr_ncid,'flux correction','latitude','longitude',&
        't',kpp_global_fields%longitude(1),kpp_global_fields%latitude(1),start(1),start(2),&
        first_timein,last_timein,time_varid)
-  !WRITE(nuout,*) 'MCKPP_READ_FCORR_3D: Returned from MCKPP_DETERMINE_NETCDF_BOUNDARIES'    
+  ! CALL mckpp_print(routine, "Returned from MCKPP_DETERMINE_NETCDF_BOUNDARIES") 
 #else
-  !WRITE(nuout,*) 'MCKPP_READ_FCORR_3D: Calling MCKPP_DETERMINE_NETCDF_BOUNDARIES'    
+  ! CALL mckpp_print(routine, "Calling MCKPP_DETERMINE_NETCDF_BOUNDARIES")
   CALL MCKPP_DETERMINE_NETCDF_BOUNDARIES(fcorr_ncid,'flux correction','latitude','longitude',&
        't',kpp_3d_fields%dlon(1),kpp_3d_fields%dlat(1),start(1),start(2),first_timein,last_timein,time_varid)
-  !WRITE(nuout,*) 'MCKPP_READ_FCORR_3D: Returned from MCKPP_DETERMINE_NETCDF_BOUNDARIES'    
+  ! CALL mckpp_print(routine, "Returned from MCKPP_DETERMINE_NETCDF_BOUNDARIES")   
 #endif
   status=NF_INQ_VARID(fcorr_ncid,'fcorr',fcorr_varid)
   IF (status .NE. NF_NOERR) CALL MCKPP_HANDLE_ERR(status)
   
-  !ndays_upd_fcorr = kpp_const_fields%ndtupdfcorr*kpp_const_fields%dto/kpp_const_fields%spd
-  !WRITE(nuout,*) ndays_upd_fcorr,FLOOR(kpp_const_fields%time,8)*NINT(kpp_const_fields%spd,8),&
+  ! ndays_upd_fcorr = kpp_const_fields%ndtupdfcorr*kpp_const_fields%dto/kpp_const_fields%spd
+  ! WRITE(message,*) ndays_upd_fcorr,FLOOR(kpp_const_fields%time,8)*NINT(kpp_const_fields%spd,8),&
   !     kpp_const_fields%ndtupdfcorr*NINT(kpp_const_fields%dto,8),&
   !     0.5*kpp_const_fields%dto/kpp_const_fields%spd*kpp_const_fields%ndtupdfcorr
-  !fcorr_time=(ndays_upd_fcorr)*FLOOR(kpp_const_fields%time,8)*NINT(kpp_const_fields%spd,8)/&
+  ! CALL mckpp_print(routine, message)
+  ! fcorr_time=(ndays_upd_fcorr)*FLOOR(kpp_const_fields%time,8)*NINT(kpp_const_fields%spd,8)/&
   !     FLOAT(kpp_const_fields%ndtupdfcorr*NINT(kpp_const_fields%dto,8))+&
   !     (0.5*kpp_const_fields%dto/kpp_const_fields%spd*kpp_const_fields%ndtupdfcorr)
   fcorr_time=kpp_const_fields%time+0.5*kpp_const_fields%dto/kpp_const_fields%spd*kpp_const_fields%ndtupdfcorr
@@ -235,22 +251,28 @@ SUBROUTINE MCKPP_READ_FCORR_3D()
            fcorr_time=fcorr_time-kpp_const_fields%fcorr_period
         ENDDO
      ELSE
-        WRITE(nuerr,*) 'MCKPP_READ_FCORR_3D: Time for which to read the flux corrections exceeds the &
-             & last time in the netCDF file and L_PERIODIC_FCORR has not been specified. &
-             & Attempting to read flux corrections will lead to an error, so aborting now ...'
+        WRITE(message,*) "Time for which to read the flux corrections exceeds the last time ", &
+           "in the netCDF file and L_PERIODIC_FCORR has not been specified. "
+        CALL mckpp_print_error(routine, message) 
+        WRITE(message,*) "Attempting to read flux corrections will lead to an error, ", &
+           "so aborting now ..."
+        CALL mckpp_print_error(routine, message) 
         CALL MCKPP_ABORT()
      ENDIF
   ENDIF
   
-  write(nuout,*) 'MCKPP_READ_FCORR_3D: Reading flux correction for time ',fcorr_time
+  WRITE(message,*) 'Reading flux correction for time ',fcorr_time
+  CALL mckpp_print(routine, message)
   start(4)=NINT((fcorr_time-first_timein)*kpp_const_fields%spd/&
        (kpp_const_fields%dto*kpp_const_fields%ndtupdfcorr))+1
   status=NF_GET_VAR1_REAL(fcorr_ncid,time_varid,start(4),time_in)
       
   IF (status .NE. NF_NOERR) CALL MCKPP_HANDLE_ERR(status)
   IF (abs(time_in-fcorr_time) .GT. 0.01) THEN
-     write(nuerr,*) 'MCKPP_READ_FCORR_3D: Cannot find time',fcorr_time,'in flux-correction input file'
-     write(nuerr,*) 'The closest I came was',time_in
+     WRITE(message,*) 'Cannot find time',fcorr_time,'in flux-correction input file'
+     CALL mckpp_print_error(routine, message) 
+     WRITE(message,*) 'The closest I came was',time_in
+     CALL mckpp_print_error(routine, message) 
      CALL MCKPP_ABORT()
   ENDIF
   status=NF_GET_VARA_REAL(fcorr_ncid,fcorr_varid,start,count,fcorr_in)

--- a/mc-kpp_read_ice.F90
+++ b/mc-kpp_read_ice.F90
@@ -144,7 +144,7 @@ SUBROUTINE mckpp_read_ice()
 #endif
      status=NF_INQ_VARID(ncid,'icedepth',varid)
      IF (status .NE. NF_NOERR) CALL MCKPP_HANDLE_ERR(status)
-     WRITE(message,*) 'MCKPP_READ_ICE: Reading climatological ICEDEPTH for time ',iceclim_time             
+     WRITE(message,*) 'Reading climatological ICEDEPTH for time ',iceclim_time             
      CALL mckpp_print(routine, message) 
      status=NF_GET_VARA_REAL(ncid,varid,start,count,var_in)
      IF (status .NE. NF_NOERR) CALL MCKPP_HANDLE_ERR(status)

--- a/mc-kpp_read_ice.F90
+++ b/mc-kpp_read_ice.F90
@@ -14,7 +14,8 @@ SUBROUTINE mckpp_read_ice()
 #else
   USE mckpp_data_fields, ONLY: kpp_3d_fields, kpp_const_fields
 #endif  
-  USE mckpp_parameters, ONLY: nx, ny, nx_globe, ny_globe, nuout, nuerr
+  USE mckpp_log_messages, ONLY: mckpp_print, mckpp_print_error, max_message_len
+  USE mckpp_parameters, ONLY: nx, ny, nx_globe, ny_globe
 
   ! Read in ice concentrations from a user-provided netCDF file.
   ! Called _only_ if L_CLIMICE is TRUE in 3D_ocn.nml.
@@ -39,6 +40,9 @@ SUBROUTINE mckpp_read_ice()
        lon_dimid,lat_dimid,ntime_file,nlon_file,nlat_file
   CHARACTER(LEN=30) tmp_name
 
+  CHARACTER(LEN=14) :: routine = "MCKPP_READ_ICE"
+  CHARACTER(LEN=max_message_len) :: message
+  
 #ifdef MCKPP_CAM3
   IF (masterproc) THEN
 #endif
@@ -87,21 +91,26 @@ SUBROUTINE mckpp_read_ice()
            iceclim_time=iceclim_time-kpp_const_fields%climice_period
         ENDDO
      ELSE
-        WRITE(nuout,*) 'Time for which to read ice exceeds the last time in the netCDF file &
-             & and L_PERIODIC_CLIMICE has not been specified.  Attempting to read ice will lead to &
-             & an error, so aborting now ...'
+        WRITE(message,*) "Time for which to read ice exceeds the last time in the netCDF file", &
+            " and L_PERIODIC_CLIMICE has not been specified."
+        CALL mckpp_print_error(routine, message) 
+        WRITE(message,*) "Attempting to read ice will lead to an error, so aborting now ..."
+        CALL mckpp_print_error(routine, message) 
         CALL MCKPP_ABORT()
      ENDIF
   ENDIF
       
-  write(nuout,*) 'MCKPP_READ_ICE: Reading climatological ICECONC for time ',iceclim_time
+  WRITE(message,*) 'Reading climatological ICECONC for time ',iceclim_time
+  CALL mckpp_print(routine, message) 
   start(3)=NINT((iceclim_time-first_timein)*kpp_const_fields%spd/&
        (kpp_const_fields%dto*kpp_const_fields%ndtupdice))+1      
   status=NF_GET_VAR1_REAL(ncid,time_varid,start(3),time_in)
   IF (status .NE. NF_NOERR) CALL MCKPP_HANDLE_ERR(status)
   IF (abs(time_in-iceclim_time) .GT. 0.01*kpp_const_fields%dtsec/kpp_const_fields%spd) THEN
-     write(nuerr,*) 'MCKPP_READ_ICE: Cannot find time,',iceclim_time,'in ice concentration climatology file'
-     write(nuerr,*) 'MCKPP_READ_ICE: The closest I came was',time_in
+     WRITE(message,*) 'Cannot find time,',iceclim_time,'in ice concentration climatology file'
+     CALL mckpp_print_error(routine, message) 
+     WRITE(message,*) 'The closest I came was',time_in
+     CALL mckpp_print_error(routine, message) 
      CALL MCKPP_ABORT()
   ENDIF
 
@@ -135,7 +144,8 @@ SUBROUTINE mckpp_read_ice()
 #endif
      status=NF_INQ_VARID(ncid,'icedepth',varid)
      IF (status .NE. NF_NOERR) CALL MCKPP_HANDLE_ERR(status)
-     WRITE(nuout,*) 'MCKPP_READ_ICE: Reading climatological ICEDEPTH for time ',iceclim_time             
+     WRITE(message,*) 'MCKPP_READ_ICE: Reading climatological ICEDEPTH for time ',iceclim_time             
+     CALL mckpp_print(routine, message) 
      status=NF_GET_VARA_REAL(ncid,varid,start,count,var_in)
      IF (status .NE. NF_NOERR) CALL MCKPP_HANDLE_ERR(status)
 #ifdef MCKPP_CAM3
@@ -161,7 +171,8 @@ SUBROUTINE mckpp_read_ice()
 #endif
      status=NF_INQ_VARID(ncid,'snowdepth',varid)
      IF (status.NE.NF_NOERR) CALL MCKPP_HANDLE_ERR(status)
-     WRITE(nuout,*) 'MCKPP_READ_ICE: Reading climatological SNOWDEPTH for time ',iceclim_time     
+     WRITE(message,*) 'Reading climatological SNOWDEPTH for time ',iceclim_time     
+     CALL mckpp_print(routine, message) 
      status=NF_GET_VARA_REAL(ncid,varid,start,count,var_in)
      IF (status.NE.NF_NOERR) CALL MCKPP_HANDLE_ERR(status)     
 #ifdef MCKPP_CAM3

--- a/mc-kpp_read_salinity.F90
+++ b/mc-kpp_read_salinity.F90
@@ -14,7 +14,8 @@ SUBROUTINE MCKPP_READ_SALINITY_3D()
 #else
   USE mckpp_data_fields, ONLY: kpp_3d_fields, kpp_const_fields
 #endif
-  USE mckpp_parameters, ONLY: nx, ny, nzp1, nx_globe, ny_globe, nuout, nuerr
+  USE mckpp_log_messages, ONLY: mckpp_print, mckpp_print_error, max_message_len
+  USE mckpp_parameters, ONLY: nx, ny, nzp1, nx_globe, ny_globe
 
   IMPLICIT NONE
   INTEGER ix,iy,iz,ipoint,sal_varid,status,lat_varid,lon_varid,z_varid,z_dimid,time_varid,&
@@ -32,6 +33,9 @@ SUBROUTINE MCKPP_READ_SALINITY_3D()
   REAL*4 ixx,jyy,first_timein,time_in,ndays_upd_sal,last_timein
   CHARACTER(LEN=30) tmp_name
   REAL*4, allocatable :: sal_in(:,:,:,:),latitudes(:),longitudes(:),z(:)
+
+  CHARACTER(LEN=22) :: routine = "MCKPP_READ_SALINITY_3D"
+  CHARACTER(LEN=max_message_len) :: message
 
 ! Read in a NetCDF file containing a 
 ! time-varying salinity field at every model vertical level.
@@ -68,16 +72,18 @@ SUBROUTINE MCKPP_READ_SALINITY_3D()
   status=NF_INQ_DIM(sal_ncid,z_dimid,tmp_name,nz_file)
   IF (status .NE. NF_NOERR) CALL MCKPP_HANDLE_ERR(status)
   IF (NZP1.ne.nz_file) THEN
-     WRITE(nuout,*) 'MCKPP_READ_SALINITY_3D: Input file for salinity climatology does not &
-          & have the correct number of vertical levels. ',&
-          'MCKPP_READ_SALINITY_3D: It should have ',NZP1,' but instead has ',nz_file
+     WRITE(message,*) "Input file for salinity climatology does not ", & 
+         "have the correct number of vertical levels."
+     CALL mckpp_print_error(routine, message) 
+     WRITE(message,*) "It should have ", NZP1, " but instead has ", nz_file
+     CALL mckpp_print_error(routine, message) 
      CALL MCKPP_ABORT()
   ELSE
      status=NF_GET_VAR_REAL(sal_ncid,z_varid,z)
      IF (status .NE. NF_NOERR) CALL MCKPP_HANDLE_ERR(status)
   ENDIF
   
-  WRITE(6,*) 'MCKPP_READ_SALINITY_3D: Calling MCKPP_DETERMINE_NETCDF_BOUNDARIES'
+  CALL mckpp_print(routine, "Calling MCKPP_DETERMINE_NETCDF_BOUNDARIES")
 #ifdef MCKPP_CAM3
   CALL MCKPP_DETERMINE_NETCDF_BOUNDARIES(sal_ncid,'salinity clim','latitude','longitude','t',&
        kpp_global_fields%longitude(1),kpp_global_fields%latitude(1),start(1),start(2),&
@@ -94,7 +100,6 @@ SUBROUTINE MCKPP_READ_SALINITY_3D()
   sal_time=(ndays_upd_sal)*(FLOOR(kpp_const_fields%time,8)*NINT(kpp_const_fields%spd,8)/&
        (kpp_const_fields%ndtupdsal*NINT(kpp_const_fields%dto,8)))+&
        (0.5*kpp_const_fields%dto/kpp_const_fields%spd*kpp_const_fields%ndtupdsal)
-  !WRITE(nuout,*) sal_time,last_timein
   
   IF (sal_time .gt. last_timein) THEN
      IF (kpp_const_fields%L_PERIODIC_SAL) THEN 
@@ -102,25 +107,31 @@ SUBROUTINE MCKPP_READ_SALINITY_3D()
            sal_time=sal_time-kpp_const_fields%sal_period
         ENDDO
      ELSE
-        WRITE(nuout,*) 'MCKPP_READ_SALINITY_3D: Time for which to read the salinity climatology exceeds &
-             & the last time in the netCDF file and L_PERIODIC_SAL has not been specified. &
-             & Attempting to read salinity climatology will lead to an error, so aborting now ...'
+        WRITE(message,*) "Time for which to read the salinity climatology exceeds the last time ", &
+            "in the netCDF file and L_PERIODIC_SAL has not been specified."
+        CALL mckpp_print_error(routine, message) 
+        WRITE(message,*) "Attempting to read salinity climatology will lead to an error, so aborting now."
+        CALL mckpp_print_error(routine, message) 
         CALL MCKPP_ABORT()
      ENDIF
   ENDIF
   
-  write(nuout,*) 'MCKPP_READ_SALINITY_3D: Reading salinity for time ',sal_time
+  WRITE(message,*) 'Reading salinity for time ',sal_time
+  CALL mckpp_print(routine, message) 
   start(4)=NINT((sal_time-first_timein)*kpp_const_fields%spd/(kpp_const_fields%dto*kpp_const_fields%ndtupdsal))+1
   status=NF_GET_VAR1_REAL(sal_ncid,time_varid,start(4),time_in)
   
   IF (status .NE. NF_NOERR) CALL MCKPP_HANDLE_ERR(status)
   IF (abs(time_in-sal_time) .GT. 0.01*kpp_const_fields%dtsec/kpp_const_fields%spd) THEN
-     write(nuerr,*) 'MCKPP_READ_SALINITY_3D: Cannot find time',sal_time,'in salinity climatology input file'
-     write(nuerr,*) 'MCKPP_READ_SALINITY_3D: The closest I came was',time_in
+     WRITE(message,*) 'Cannot find time',sal_time,'in salinity climatology input file'
+     CALL mckpp_print_error(routine, message) 
+     WRITE(message,*) 'The closest I came was',time_in
+     CALL mckpp_print_error(routine, message) 
      CALL MCKPP_ABORT()
   ENDIF
   status=NF_GET_VARA_REAL(sal_ncid,sal_varid,start,count,sal_in)
-  WRITE(nuout,*) 'MCKPP_READ_SALINITY_3D: Read salinity for time ',sal_time
+  WRITE(message,*) 'MCKPP_READ_SALINITY_3D: Read salinity for time ',sal_time
+  CALL mckpp_print(routine, message) 
   status=NF_CLOSE(sal_ncid)
 
 #ifdef MCKPP_CAM3
@@ -140,7 +151,6 @@ SUBROUTINE MCKPP_READ_SALINITY_3D()
              kpp_3d_fields(ichnk)%Sref(1:ncol)
      ENDDO
   ENDDO
-  !WRITE(6,*) kpp_3d_fields(begchunk)%sal_clim(:,1)
 #else
   ! Convert from REAL*4 to REAL*(default precision). Put all (NX,NY) points
   ! into one long array with dimension NPTS.      

--- a/mc-kpp_read_salinity.F90
+++ b/mc-kpp_read_salinity.F90
@@ -130,7 +130,7 @@ SUBROUTINE MCKPP_READ_SALINITY_3D()
      CALL MCKPP_ABORT()
   ENDIF
   status=NF_GET_VARA_REAL(sal_ncid,sal_varid,start,count,sal_in)
-  WRITE(message,*) 'MCKPP_READ_SALINITY_3D: Read salinity for time ',sal_time
+  WRITE(message,*) 'Read salinity for time ',sal_time
   CALL mckpp_print(routine, message) 
   status=NF_CLOSE(sal_ncid)
 

--- a/mc-kpp_read_saltcorrections.F90
+++ b/mc-kpp_read_saltcorrections.F90
@@ -171,6 +171,9 @@ SUBROUTINE MCKPP_READ_SFCORR_3D()
   CHARACTER(LEN=30) tmp_name
   REAL*4, allocatable :: sfcorr_in(:,:,:,:),longitudes(:),latitudes(:),z(:)
   
+  CHARACTER(LEN=20) :: routine = "MCKPP_READ_SFCORR_3D"
+  CHARACTER(LEN=max_message_len) :: message
+
   ! Read in a NetCDF file containing a 
   ! time-varying salinity correction at every model vertical level.
   ! Frequency of read is controlled by ndtupdsfcorr in the namelist

--- a/mc-kpp_read_saltcorrections.F90
+++ b/mc-kpp_read_saltcorrections.F90
@@ -14,7 +14,8 @@ SUBROUTINE MCKPP_READ_SFCORR_2D()
 #else
   USE mckpp_data_fields, ONLY: kpp_3d_fields,kpp_const_fields
 #endif
-  USE mckpp_parameters, ONLY: nx, ny, nx_globe, ny_globe, nzp1, nuout, nuerr
+  USE mckpp_log_messages, ONLY: mckpp_print, mckpp_print_error, max_message_len
+  USE mckpp_parameters, ONLY: nx, ny, nx_globe, ny_globe, nzp1
 
   IMPLICIT NONE
   INTEGER start(3),count(3)
@@ -31,9 +32,11 @@ SUBROUTINE MCKPP_READ_SFCORR_2D()
   REAL :: sfcorr_time
   REAL*4 ixx,jyy,first_timein,time_in,ndays_upd_sfcorr,last_timein
   REAL*4, ALLOCATABLE :: sfcorr_twod_in(:,:,:),latitudes(:),longitudes(:),z(:)
-
   CHARACTER(LEN=30) tmp_name
   
+  CHARACTER(LEN=20) :: routine = "MCKPP_READ_SFCORR_2D"
+  CHARACTER(LEN=max_message_len) :: message
+    
   ! Read in a NetCDF file containing a time-varying salinity correction
   ! at the surface only.  Frequency of read is controlled by ndtupdsfcorr
   ! in the namelist
@@ -63,16 +66,16 @@ SUBROUTINE MCKPP_READ_SFCORR_2D()
   count(:)=(/my_nx,my_ny,1/)
 
 #ifdef MCKPP_CAM3  
-  !WRITE(nuout,*) 'MCKPP_READ_SFCORR_2D: Calling MCKPP_DETERMINE_NETCDF_BOUNDARIES'    
+  ! CALL mckpp_print(routine, "Calling MCKPP_DETERMINE_NETCDF_BOUNDARIES") 
   CALL MCKPP_DETERMINE_NETCDF_BOUNDARIES(sfcorr_ncid,'salinity correction','latitude','longitude',&
        't',kpp_global_fields%longitude(1),kpp_global_fields%latitude(1),start(1),start(2),&
        first_timein,last_timein,time_varid)
-  !WRITE(nuout,*) 'MCKPP_READ_SFCORR_2D: Returned from MCKPP_DETERMINE_NETCDF_BOUNDARIES'        
+  ! CALL mckpp_print(routine, "Returned from MCKPP_DETERMINE_NETCDF_BOUNDARIES") 
 #else
-  !WRITE(nuout,*) 'MCKPP_READ_SFCORR_2D: Calling MCKPP_DETERMINE_NETCDF_BOUNDARIES'    
+  ! CALL mckpp_print(routine, "Calling MCKPP_DETERMINE_NETCDF_BOUNDARIES") 
   CALL MCKPP_DETERMINE_NETCDF_BOUNDARIES(sfcorr_ncid,'salinity correction','latitude','longitude',&
        't',kpp_3d_fields%dlon(1),kpp_3d_fields%dlat(1),start(1),start(2),first_timein,last_timein,time_varid)
-  !WRITE(nuout,*) 'MCKPP_READ_SFCORR_2D: Returned from MCKPP_DETERMINE_NETCDF_BOUNDARIES'            
+  ! CALL mckpp_print(routine, "Returned from MCKPP_DETERMINE_NETCDF_BOUNDARIES") 
 #endif
  
   status=NF_INQ_VARID(sfcorr_ncid,'sfcorr',sfcorr_varid)
@@ -89,21 +92,27 @@ SUBROUTINE MCKPP_READ_SFCORR_2D()
            sfcorr_time=sfcorr_time-kpp_const_fields%sfcorr_period
         ENDDO
      ELSE
-        WRITE(nuerr,*) 'MCKPP_READ_SFCORR_2D: Time for which to read the salinity corrections &
-             & exceeds the last time in the netCDF file and L_PERIODIC_SFCORR has not been specified. &
-             & Attempting to read salinity corrections will lead to an error, so aborting now ...'
+        WRITE(message,*) "Time for which to read the salinity corrections exceeds the last time ", &
+           "in the netCDF file and L_PERIODIC_SFCORR has not been specified. "
+        CALL mckpp_print_error(routine, message) 
+        WRITE(message,*) "Attempting to read salinity corrections will lead to an error, ", &
+           "so aborting now ..."
+        CALL mckpp_print_error(routine, message) 
         CALL MCKPP_ABORT()
      ENDIF
   ENDIF
 
-  WRITE(nuout,*) 'MCKPP_READ_SFCORR_2D: Reading salinity correction for time ',sfcorr_time
+  WRITE(message,*) 'Reading salinity correction for time ',sfcorr_time
+  CALL mckpp_print(routine, message)
   start(3)=NINT((sfcorr_time-first_timein)*kpp_const_fields%spd/(kpp_const_fields%dto*kpp_const_fields%ndtupdsfcorr))+1
   status=NF_GET_VAR1_REAL(sfcorr_ncid,time_varid,start(3),time_in)
   
   IF (status .NE. NF_NOERR) CALL MCKPP_HANDLE_ERR(status)
   IF (abs(time_in-sfcorr_time) .GT. 0.03*kpp_const_fields%dtsec/kpp_const_fields%spd) THEN
-     write(nuerr,*) 'MCKPP_READ_SFCORR_2D: Cannot find time',sfcorr_time,'in flux-correction input file'
-     write(nuerr,*) 'MCKPP_READ_SFCORR_3D: The closest I came was',time_in
+     WRITE(message,*) 'Cannot find time',sfcorr_time,'in flux-correction input file'
+     CALL mckpp_print_error(routine, message) 
+     WRITE(message,*) 'The closest I came was',time_in
+     CALL mckpp_print_error(routine, message) 
      CALL MCKPP_ABORT()
   ENDIF
   status=NF_GET_VARA_REAL(sfcorr_ncid,sfcorr_varid,start,count,sfcorr_twod_in)
@@ -142,7 +151,8 @@ SUBROUTINE MCKPP_READ_SFCORR_3D()
 #else
   USE mckpp_data_fields, ONLY: kpp_3d_fields, kpp_const_fields
 #endif
-  USE mckpp_parameters, ONLY: nx, ny, nx_globe, ny_globe, nzp1, nuout, nuerr
+  USE mckpp_log_messages, ONLY: mckpp_print, mckpp_print_error, max_message_len
+  USE mckpp_parameters, ONLY: nx, ny, nx_globe, ny_globe, nzp1
       
   IMPLICIT NONE
 #include <netcdf.inc>
@@ -196,9 +206,10 @@ SUBROUTINE MCKPP_READ_SFCORR_3D()
   status=NF_INQ_DIM(sfcorr_ncid,z_dimid,tmp_name,nz_file)
   IF (status .NE. NF_NOERR) CALL MCKPP_HANDLE_ERR(status)
   IF (NZP1.ne.nz_file) THEN
-     WRITE(nuerr,*) 'MCKPP_READ_SFCORR_3D: Input file for salinity corrections does not have the &
-          & correct number of vertical levels. ',&
-          'It should have ',NZP1,' but instead has ',nz_file
+     WRITE(message,*) "Input file for salinity corrections does not have the correct number of vertical levels."
+     CALL mckpp_print_error(routine, message) 
+     WRITE(message,*) "It should have ", NZP1, " but instead has ", nz_file
+     CALL mckpp_print_error(routine, message) 
      CALL MCKPP_ABORT()
   ELSE
      status=NF_GET_VAR_REAL(sfcorr_ncid,z_varid,z)
@@ -206,25 +217,26 @@ SUBROUTINE MCKPP_READ_SFCORR_3D()
   ENDIF
 
 #ifdef MCKPP_CAM3
-  !WRITE(nuout,*) 'MCKPP_READ_SFCORR_3D: Calling MCKPP_DETERMINE_NETCDF_BOUNDARIES'    
+  ! CALL mckpp_print(routine, "Calling MCKPP_DETERMINE_NETCDF_BOUNDARIES") 
   CALL MCKPP_DETERMINE_NETCDF_BOUNDARIES(sfcorr_ncid,'salinity correction','latitude','longitude',&
        't',kpp_global_fields%longitude(1),kpp_global_fields%latitude(1),start(1),start(2),&
        first_timein,last_timein,time_varid)
-  !WRITE(nuout,*) 'MCKPP_READ_SFCORR_3D: Returned from MCKPP_DETERMINE_NETCDF_BOUNDARIES'        
+  ! CALL mckpp_print(routine, "Returned from MCKPP_DETERMINE_NETCDF_BOUNDARIES") 
 
 #else
-  !WRITE(nuout,*) 'MCKPP_READ_SFCORR_3D: Calling MCKPP_DETERMINE_NETCDF_BOUNDARIES'    
+  ! CALL mckpp_print(routine, "Calling MCKPP_DETERMINE_NETCDF_BOUNDARIES") 
   CALL MCKPP_DETERMINE_NETCDF_BOUNDARIES(sfcorr_ncid,'salinity correction','latitude','longitude',&
        't',kpp_3d_fields%dlon(1),kpp_3d_fields%dlat(1),start(1),start(2),first_timein,last_timein,time_varid)
-  !WRITE(nuout,*) 'MCKPP_READ_SFCORR_3D: Returned from MCKPP_DETERMINE_NETCDF_BOUNDARIES'        
+  ! CALL mckpp_print(routine, "Returned from MCKPP_DETERMINE_NETCDF_BOUNDARIES") 
 #endif
   status=NF_INQ_VARID(sfcorr_ncid,'sfcorr',sfcorr_varid)
   IF (status .NE. NF_NOERR) CALL MCKPP_HANDLE_ERR(status)
   
 !  ndays_upd_sfcorr = kpp_const_fields%ndtupdsfcorr*kpp_const_fields%dto/kpp_const_fields%spd
-!  WRITE(nuout,*) ndays_upd_sfcorr,FLOOR(kpp_const_fields%time,8)*NINT(kpp_const_fields%spd,8),&
+!  WRITE(message,*) ndays_upd_sfcorr,FLOOR(kpp_const_fields%time,8)*NINT(kpp_const_fields%spd,8),&
 !       kpp_const_fields%ndtupdsfcorr*NINT(kpp_const_fields%dto,8),&
 !       0.5*kpp_const_fields%dto/kpp_const_fields%spd*kpp_const_fields%ndtupdsfcorr
+!  CALL mckpp_print_error(routine, message) 
 !  sfcorr_time=(ndays_upd_sfcorr)*FLOOR(kpp_const_fields%time,8)*NINT(kpp_const_fields%spd,8)/&
 !       FLOAT(kpp_const_fields%ndtupdsfcorr*NINT(kpp_const_fields%dto,8))+&
 !       (0.5*kpp_const_fields%dto/kpp_const_fields%spd*kpp_const_fields%ndtupdsfcorr)  
@@ -236,22 +248,28 @@ SUBROUTINE MCKPP_READ_SFCORR_3D()
            sfcorr_time=sfcorr_time-kpp_const_fields%sfcorr_period
         ENDDO
      ELSE
-        WRITE(nuerr,*) 'MCKPP_READ_SFCORR_3D: Time for which to read the salinity corrections exceeds the &
-             & last time in the netCDF file and L_PERIODIC_SFCORR has not been specified. &
-             & Attempting to read salinity corrections will lead to an error, so aborting now ...'
+        WRITE(message,*) "Time for which to read the salinity corrections exceeds the last time ", &
+           "in the netCDF file and L_PERIODIC_SFCORR has not been specified. "
+        CALL mckpp_print_error(routine, message) 
+        WRITE(message,*) "Attempting to read salinity corrections will lead to an error, ", &
+           "so aborting now ..."
+        CALL mckpp_print_error(routine, message) 
         CALL MCKPP_ABORT()
      ENDIF
   ENDIF
   
-  write(nuout,*) 'MCKPP_READ_SFCORR_3D: Reading salinity correction for time ',sfcorr_time
+  WRITE(message,*) 'Reading salinity correction for time ',sfcorr_time
+  CALL mckpp_print(routine, message)
   start(4)=NINT((sfcorr_time-first_timein)*kpp_const_fields%spd/&
        (kpp_const_fields%dto*kpp_const_fields%ndtupdsfcorr))+1  
   status=NF_GET_VAR1_REAL(sfcorr_ncid,time_varid,start(4),time_in)
       
   IF (status .NE. NF_NOERR) CALL MCKPP_HANDLE_ERR(status)
   IF (abs(time_in-sfcorr_time) .GT. 0.01) THEN
-     write(nuerr,*) 'MCKPP_READ_SFCORR_3D: Cannot find time',sfcorr_time,'in flux-correction input file'
-     write(nuerr,*) 'MCKPP_READ_SFCORR_3D: The closest I came was',time_in
+     WRITE(message,*) 'Cannot find time',sfcorr_time,'in flux-correction input file'
+     CALL mckpp_print_error(routine, message) 
+     WRITE(message,*) 'The closest I came was',time_in
+     CALL mckpp_print_error(routine, message) 
      CALL MCKPP_ABORT()
   ENDIF
   status=NF_GET_VARA_REAL(sfcorr_ncid,sfcorr_varid,start,count,sfcorr_in)

--- a/mc-kpp_read_temperatures.F90
+++ b/mc-kpp_read_temperatures.F90
@@ -194,7 +194,7 @@ SUBROUTINE MCKPP_READ_TEMPERATURES_BOTTOM()
        nlat_file,nlon_file,ntime_file,count(3),start(3),ix,iy,ipoint
   CHARACTER(LEN=30) tmp_name
 
-  CHARACTER(LEN=26) :: routine = "MCKPP_READ_TEMPERATURES_3D"
+  CHARACTER(LEN=30) :: routine = "MCKPP_READ_TEMPERATURES_BOTTOM"
   CHARACTER(LEN=max_message_len) :: message
   
 #ifdef MCKPP_CAM3

--- a/mc-kpp_read_temperatures.F90
+++ b/mc-kpp_read_temperatures.F90
@@ -14,7 +14,8 @@ SUBROUTINE MCKPP_READ_TEMPERATURES_3D()
 #else
   USE mckpp_data_fields, ONLY: kpp_3d_fields, kpp_const_fields
 #endif
-  USE mckpp_parameters, ONLY: nx, ny, nx_globe, ny_globe, nzp1, nuout, nuerr
+  USE mckpp_log_messages, ONLY: mckpp_print, mckpp_print_error, max_message_len
+  USE mckpp_parameters, ONLY: nx, ny, nx_globe, ny_globe, nzp1
 
   IMPLICIT NONE
 #include <netcdf.inc>
@@ -33,6 +34,9 @@ SUBROUTINE MCKPP_READ_TEMPERATURES_3D()
   REAL*4 ixx,jyy,first_timein,time_in,ndays_upd_ocnT,last_timein
   CHARACTER(LEN=30) tmp_name
 
+  CHARACTER(LEN=26) :: routine = "MCKPP_READ_TEMPERATURES_3D"
+  CHARACTER(LEN=max_message_len) :: message
+  
 #ifdef MCKPP_CAM3
   IF (masterproc) THEN
 #endif
@@ -62,27 +66,29 @@ SUBROUTINE MCKPP_READ_TEMPERATURES_3D()
   status=NF_INQ_DIM(ocnT_ncid,z_dimid,tmp_name,nz_file)
   IF (status .NE. NF_NOERR) CALL MCKPP_HANDLE_ERR(status)
   IF (NZP1.ne.nz_file) THEN
-     WRITE(nuerr,*) 'MCKPP_READ_TEMPERATURES_3D: Input file for ocean temperature climatology &
-          & does not have the correct number of vertical levels. &
-          & It should have ',NZP1,' but instead has ',nz_file
+     WRITE(message,*) "Input file for ocean temperature climatology does not have the ", & 
+         "correct number of vertical levels."
+     CALL mckpp_print_error(routine, message) 
+     WRITE(message,*) "It should have ", NZP1, " but instead has ", nz_file
+     CALL mckpp_print_error(routine, message) 
      CALL MCKPP_ABORT()
   ELSE
      status=NF_GET_VAR_REAL(ocnT_ncid,z_varid,z)
      IF (status .NE. NF_NOERR) CALL MCKPP_HANDLE_ERR(status)
-     WRITE(nuout,*) 'Read in depths from the ocean temperature climatology input file'
+     CALL mckpp_print(routine, "Read in depths from the ocean temperature climatology input file")
   ENDIF
 
 #ifdef MCKPP_CAM3
-  WRITE(nuout,*) 'MCKPP_READ_TEMPERATURES_3D: Calling MCKPP_DETERMINE_NETCDF_BOUNDARIES'  
+  CALL mckpp_print(routine, 'Calling MCKPP_DETERMINE_NETCDF_BOUNDARIES')
   CALL MCKPP_DETERMINE_NETCDF_BOUNDARIES(ocnT_ncid,'ocean temp clim','latitude','longitude','t',&
        kpp_global_fields%longitude(1),kpp_global_fields%latitude(1),start(1),start(2),first_timein,&
        last_timein,time_varid)
-  WRITE(nuout,*) 'MCKPP_READ_TEMPERATURES_3D: Returned from MCKPP_DETERMINE_NETCDF_BOUNDARIES'
+  CALL mckpp_print(routine, 'Returned from MCKPP_DETERMINE_NETCDF_BOUNDARIES')
 #else
-  WRITE(nuout,*) 'MCKPP_READ_TEMPERATURES_3D: Calling MCKPP_DETERMINE_NETCDF_BOUNDARIES'
+  CALL mckpp_print(routine, 'Calling MCKPP_DETERMINE_NETCDF_BOUNDARIES')
   CALL MCKPP_DETERMINE_NETCDF_BOUNDARIES(ocnT_ncid,'ocean temp clim','latitude','longitude','t',kpp_3d_fields%dlon(1),&
-       kpp_3d_fields%dlat(1),start(1),start(2),first_timein,last_timein,time_varid)
-  WRITE(nuout,*) 'MCKPP_READ_TEMPERATURES_3D: Returned from MCKPP_DETERMINE_NETCDF_BOUNDARIES'
+      kpp_3d_fields%dlat(1),start(1),start(2),first_timein,last_timein,time_varid)
+  CALL mckpp_print(routine, 'Returned from MCKPP_DETERMINE_NETCDF_BOUNDARIES')
 #endif
   
   status=NF_INQ_VARID(ocnT_ncid,'temperature',ocnT_varid)
@@ -92,30 +98,33 @@ SUBROUTINE MCKPP_READ_TEMPERATURES_3D()
   ocnT_time=(ndays_upd_ocnT)*(FLOOR(kpp_const_fields%time,8)*NINT(kpp_const_fields%spd,8)/&
        (kpp_const_fields%ndtupdocnT*NINT(kpp_const_fields%dto,8)))+&
        (0.5*kpp_const_fields%dto/kpp_const_fields%spd*kpp_const_fields%ndtupdocnT)
-  WRITE(nuout,*) ocnT_time,last_timein
-     
+
   IF (ocnT_time .gt. last_timein) THEN
      IF (kpp_const_fields%L_PERIODIC_OCNT) THEN 
         DO WHILE (ocnT_time .gt. last_timein)
            ocnT_time=ocnT_time-kpp_const_fields%ocnT_period
         ENDDO
      ELSE
-        WRITE(nuerr,*) 'MCKPP_READ_TEMPERATURES_3D: Time for which to read the ocean temperatures exceeds &
-             & the last time in the netCDF file and L_PERIODIC_OCNT has not been specified.  Attempting to &
-             & read ocean temperatures will lead to an error, so aborting now ...'
+        WRITE(message,*) "Time for which to read the ocean temperatures exceeds the last time ", &
+            "in the netCDF file and L_PERIODIC_OCNT has not been specified."
+        CALL mckpp_print_error(routine, message) 
+        WRITE(message,*) "Attempting to read ocean temperatures will lead to an error, so aborting now."
+        CALL mckpp_print_error(routine, message) 
         CALL MCKPP_ABORT()
      ENDIF
   ENDIF
 
-  write(nuout,*) 'MCKPP_READ_TEMPERATUERS_3D: Reading ocean temperature for time ',ocnT_time
+  WRITE(message,*) 'Reading ocean temperature for time ',ocnT_time
+  CALL mckpp_print(routine, message)
   start(4)=NINT((ocnT_time-first_timein)*kpp_const_fields%spd/(kpp_const_fields%dto*kpp_const_fields%ndtupdocnT))+1
   status=NF_GET_VAR1_REAL(ocnT_ncid,time_varid,start(4),time_in)
   
   IF (status .NE. NF_NOERR) CALL MCKPP_HANDLE_ERR(status)
   IF (abs(time_in-ocnT_time) .GT. 0.01*kpp_const_fields%dtsec/kpp_const_fields%spd) THEN
-     write(nuerr,*) 'MCKPP_READ_TEMPERATURES_3D: Cannot find time ',ocnT_time,&
-          ' in ocean temperature climatology input file'
-     write(nuerr,*) 'MCKPP_READ_TEMPERATURES_3D: The closest I came was',time_in
+     WRITE(message,*) 'Cannot find time ', ocnT_time, ' in ocean temperature climatology input file'
+     CALL mckpp_print_error(routine, message) 
+     WRITE(message,*) 'The closest I came was',time_in
+     CALL mckpp_print_error(routine, message) 
      CALL MCKPP_ABORT()
   ENDIF
   status=NF_GET_VARA_REAL(ocnT_ncid,ocnT_varid,start,count,ocnT_in)
@@ -164,7 +173,8 @@ SUBROUTINE MCKPP_READ_TEMPERATURES_BOTTOM()
 #else
   USE mckpp_data_fields, ONLY: kpp_3d_fields, kpp_const_fields
 #endif
-  USE mckpp_parameters, ONLY: nx, ny, nx_globe, ny_globe, nuout, nuerr
+  USE mckpp_log_messages, ONLY: mckpp_print, mckpp_print_error, max_message_len
+  USE mckpp_parameters, ONLY: nx, ny, nx_globe, ny_globe
 
   IMPLICIT NONE
   
@@ -183,6 +193,9 @@ SUBROUTINE MCKPP_READ_TEMPERATURES_BOTTOM()
   INTEGER varid,time_varid,lat_varid,lon_varid,time_dimid,lat_dimid,lon_dimid,&
        nlat_file,nlon_file,ntime_file,count(3),start(3),ix,iy,ipoint
   CHARACTER(LEN=30) tmp_name
+
+  CHARACTER(LEN=26) :: routine = "MCKPP_READ_TEMPERATURES_3D"
+  CHARACTER(LEN=max_message_len) :: message
   
 #ifdef MCKPP_CAM3
   IF (masterproc) THEN
@@ -208,7 +221,7 @@ SUBROUTINE MCKPP_READ_TEMPERATURES_BOTTOM()
   status=NF_INQ_VARID(ncid,'T',varid)
   IF (status .NE. NF_NOERR) CALL MCKPP_HANDLE_ERR(status)
   
-  WRITE(nuout,*) 'MCKPP_READ_TEMPERATURES_BOTTOM: Calling MCKPP_DETERMINE_NETCDF_BOUNDARIES'    
+  CALL mckpp_print(routine, "Calling MCKPP_DETERMINE_NETCDF_BOUNDARIES") 
 #ifdef MCKPP_CAM3 
   CALL MCKPP_DETERMINE_NETCDF_BOUNDARIES(ncid,'bottom temp climatology','latitude','longitude',&
        't',kpp_global_fields%longitude(1),kpp_global_fields%latitude(1),start(1),start(2),&
@@ -217,7 +230,7 @@ SUBROUTINE MCKPP_READ_TEMPERATURES_BOTTOM()
   CALL MCKPP_DETERMINE_NETCDF_BOUNDARIES(ncid,'bottom temp climatology','latitude','longitude',&
        't',kpp_3d_fields%dlon(1),kpp_3d_fields%dlat(1),start(1),start(2),first_timein,last_timein,time_varid)
 #endif
-  WRITE(nuout,*) 'MCKPP_READ_TEMPERATURES_BOTTOM: Returned from MCKPP_DETERMINE_NETCDF_BOUNDARIES'
+  CALL mckpp_print(routine, "Returned from MCKPP_DETERMINE_NETCDF_BOUNDARIES")
   
   bottomclim_time=kpp_const_fields%time+0.5*kpp_const_fields%dto/kpp_const_fields%spd*kpp_const_fields%ndtupdbottom
   IF (bottomclim_time .gt. last_timein) THEN
@@ -226,23 +239,27 @@ SUBROUTINE MCKPP_READ_TEMPERATURES_BOTTOM()
            bottomclim_time=bottomclim_time-kpp_const_fields%bottom_temp_period
         ENDDO
      ELSE
-        WRITE(nuerr,*) 'MCKPP_READ_TEMPERATURES_BOTTOM: Time for which to read bottom temperature exceeds &
-             & the last time in the netCDF file and L_PERIODIC_BOTTOM_TEMP has not been specified.  &
-             & Attempting to read bottom temperature will lead to an error, so aborting now...'
+        WRITE(message,*) "Time for which to read bottom temperature exceeds the last time ", & 
+            "in the netCDF file and L_PERIODIC_BOTTOM_TEMP has not been specified."
+        CALL mckpp_print_error(routine, message) 
+        WRITE(message,*) "Attempting to read bottom temperature will lead to an error, so aborting now."
+        CALL mckpp_print_error(routine, message) 
         CALL MCKPP_ABORT()
      ENDIF
   ENDIF
  
-  write(nuout,*) 'MCKPP_READ_TEMPERATURES_BOTTOM: Reading climatological bottom temp for time ',bottomclim_time
+  WRITE(message,*) 'Reading climatological bottom temp for time ',bottomclim_time
   start(3)=NINT((bottomclim_time-first_timein)*kpp_const_fields%spd/&
        (kpp_const_fields%dto*kpp_const_fields%ndtupdbottom))+1
   
   status=NF_GET_VAR1_REAL(ncid,time_varid,start(3),time_in)
   IF (status .NE. NF_NOERR) CALL MCKPP_HANDLE_ERR(status)
   IF (abs(time_in-bottomclim_time) .GT. 0.01*kpp_const_fields%dtsec/kpp_const_fields%spd) THEN
-     write(nuerr,*) 'MCKPP_READ_TEMPERATURES_BOTTOM: Cannot find time',bottomclim_time,&
-          'in bottom temperature climatology file'
-     write(nuerr,*) 'MCKPP_READ_TEMPERATURES_BOTTOM: The closest I came was',time_in
+     WRITE(message,*) 'Cannot find time', bottomclim_time, &
+         'in bottom temperature climatology file'
+     CALL mckpp_print_error(routine, message) 
+     WRITE(message,*) 'The closest I came was', time_in
+     CALL mckpp_print_error(routine, message) 
      CALL MCKPP_ABORT()
   ENDIF
   status=NF_GET_VARA_REAL(ncid,varid,start,count,var_in)

--- a/mc-kpp_restart_io.F90
+++ b/mc-kpp_restart_io.F90
@@ -2,11 +2,16 @@
 SUBROUTINE MCKPP_RESTART_IO_READ()
 
   USE mckpp_data_fields, ONLY: kpp_3d_fields,kpp_const_fields
-  USE mckpp_parameters, ONLY: npts, nzp1, nuout, nuerr
+  USE mckpp_log_messages, ONLY: mckpp_print, max_message_len
+  USE mckpp_parameters, ONLY: npts, nzp1
   
   IMPLICIT NONE
   
-  WRITE(nuout,*) 'Total number of points = ',REAL(NPTS)*REAL(NZP1)
+  CHARACTER(LEN=21) :: routine = "MCKPP_RESTART_IO_READ"
+  CHARACTER(LEN=max_message_len) :: message
+  
+  WRITE(message,*) 'Total number of points = ',REAL(NPTS)*REAL(NZP1)
+  CALL mckpp_print(routine, message)
   IF ( REAL(NPTS)*REAL(NZP1) .LT. 3000000. ) THEN   
      OPEN(30,FILE=kpp_const_fields%restart_infile,status='unknown',form='unformatted')
      READ(30) kpp_const_fields%time,kpp_3d_fields%U,kpp_3d_fields%X,kpp_3d_fields%CP,&
@@ -27,9 +32,12 @@ SUBROUTINE MCKPP_RESTART_IO_READ()
   ENDIF
 
   IF (abs(kpp_const_fields%time-kpp_const_fields%startt) .GT. 1.e-4) THEN 
-     WRITE(nuerr,*) 'Start time doesn''t match the restart record'
-     WRITE(nuerr,*) 'Start time in restart record = ',kpp_const_fields%time
-     WRITE(nuerr,*) 'Start time in namelist = ',kpp_const_fields%startt
+     WRITE(message,*) 'Start time doesn''t match the restart record'
+     CALL mckpp_print_error(routine, message) 
+     WRITE(message,*) 'Start time in restart record = ',kpp_const_fields%time
+     CALL mckpp_print_error(routine, message) 
+     WRITE(message,*) 'Start time in namelist = ',kpp_const_fields%startt
+     CALL mckpp_print_error(routine, message) 
      CALL MCKPP_ABORT()
   ENDIF
   
@@ -39,9 +47,13 @@ END SUBROUTINE MCKPP_RESTART_IO_READ
 SUBROUTINE MCKPP_RESTART_IO_WRITE()
  
   USE mckpp_data_fields, ONLY: kpp_3d_fields,kpp_const_fields
-  USE mckpp_parameters, ONLY: npts, nzp1, nuout, nuerr
+  USE mckpp_log_messages, ONLY: mckpp_print, max_message_len
+  USE mckpp_parameters, ONLY: npts, nzp1
      
   IMPLICIT NONE
+  
+  CHARACTER(LEN=22) :: routine = "MCKPP_RESTART_IO_WRITE"
+  CHARACTER(LEN=max_message_len) :: message
     
   ! When the number of points in the model (NX*NY*NZP1) becomes
   ! quite large, we exceed the maximum size for Fortran unformatted
@@ -49,7 +61,8 @@ SUBROUTINE MCKPP_RESTART_IO_WRITE()
   ! works around this by splitting the restart file in two.
   ! %Us and %Xs are the largest fields, so they get their own file.
 
-  WRITE(nuout,*) 'Total number of points = ',REAL(NPTS)*REAL(NZP1)
+  WRITE(message,*) 'Total number of points = ',REAL(NPTS)*REAL(NZP1)
+  CALL mckpp_print(routine, message)
   IF ( REAL(NPTS)*REAL(NZP1) .LT. 3000000. ) THEN
      OPEN(31,FILE=kpp_const_fields%restart_outfile,status='unknown',form='unformatted')
      WRITE(31) kpp_const_fields%time,kpp_3d_fields%U,kpp_3d_fields%X,kpp_3d_fields%CP,&
@@ -89,7 +102,8 @@ SUBROUTINE MCKPP_RESTART_IO_WRITE_NETCDF()
 #else
   USE mckpp_data_fields, ONLY: kpp_3d_fields, kpp_const_fields
 #endif
-  USE mckpp_parameters, ONLY: nx, ny, npts, nzp1, nzp1tmax, nuout, nuerr
+  USE mckpp_log_messages, ONLY: mckpp_print, mckpp_print_error, max_message_len
+  USE mckpp_parameters, ONLY: nx, ny, npts, nzp1, nzp1tmax
 
   IMPLICIT NONE
 #include <netcdf.inc>
@@ -115,6 +129,10 @@ SUBROUTINE MCKPP_RESTART_IO_WRITE_NETCDF()
   REAL*4, allocatable :: lon_out(:),lat_out(:),z_out(:)
   REAL*4 :: delta
 
+  CHARACTER(LEN=29) :: routine = "MCKPP_RESTART_IO_WRITE_NETCDF"
+  CHARACTER(LEN=max_message_len) :: message
+  
+
 #ifdef MCKPP_CAM3
   IF (masterproc) THEN
 
@@ -134,12 +152,11 @@ SUBROUTINE MCKPP_RESTART_IO_WRITE_NETCDF()
   ALLOCATE( z_out(1:NZP1tmax+1) ) 
 
   WRITE(netcdf_restart_outfile,'(A17,A3)') kpp_const_fields%restart_outfile,'.nc'
-  WRITE(nuout,*) netcdf_restart_outfile
 
   status=NF_CREATE(netcdf_restart_outfile,NF_CLOBBER,ncid)
-  WRITE(nuout,*) status,netcdf_restart_outfile
   IF (status .NE. NF_NOERR) CALL MCKPP_HANDLE_ERR
-  WRITE(nuout,*) 'Created file '//netcdf_restart_outfile
+  WRITE(message,*) 'Created file ', netcdf_restart_outfile
+  CALL mckpp_print(routine, message)
 #ifdef MCKPP_CAM3
   IF (my_nx .gt. 1) delta=kpp_global_fields%longitude(2)-kpp_global_fields%longitude(1)
 #else
@@ -158,7 +175,6 @@ SUBROUTINE MCKPP_RESTART_IO_WRITE_NETCDF()
   CALL MCKPP_NCDF_DEF_DIM(ncid,dim_dimids(6),2,dim_varids(6),'intcnt','unitless',0.0,' ')
 
   DO ivar=1,nvars
-     WRITE(nuout,*) ivar
      SELECT CASE(ivar)
      CASE (1)
         CALL MCKPP_NCDF_DEF_VAR(ncid,varids(ivar),1,(/dim_dimids(5)/),'time','days','time')
@@ -256,7 +272,6 @@ SUBROUTINE MCKPP_RESTART_IO_WRITE_NETCDF()
 ENDIF ! End of masterproc section
 #endif
   DO ivar=1,nvars
-     WRITE(nuout,*) ivar
      SELECT CASE(ivar)
      CASE(1)
 #ifdef MCKPP_CAM3
@@ -273,7 +288,6 @@ ENDIF ! End of masterproc section
            ncol=get_ncols_p(ichnk)
            temp_chunk(1:ncol,ichnk,1:NZP1)=kpp_3d_fields(ichnk)%U(1:ncol,1:NZP1,1)
         ENDDO
-        !WRITE(nuout,*) temp_chunk
         CALL MCKPP_REFORMAT_MASK_OUTPUT_CHUNK(temp_chunk,NZP1,1e20,temp_chunk)
         CALL gather_chunk_to_field(1,1,NZP1,PLON,temp_chunk(1,begchunk,1),temp_global_3d(:,:,:,1))
         IF (masterproc) THEN
@@ -686,7 +700,8 @@ SUBROUTINE MCKPP_RESTART_IO_READ_NETCDF()
 #else
   USE mckpp_data_fields, ONLY: kpp_3d_fields, kpp_const_fields
 #endif
-  USE mckpp_parameters, ONLY: nx, ny, npts, nzp1, nuout, nuerr
+  USE mckpp_log_messages, ONLY: mckpp_print, mckpp_print_error, max_message_len
+  USE mckpp_parameters, ONLY: nx, ny, npts, nzp1
 
   IMPLICIT NONE
 #include <netcdf.inc>
@@ -712,6 +727,9 @@ SUBROUTINE MCKPP_RESTART_IO_READ_NETCDF()
          'rho  ','hmix ','kmix ','Sref ','SSref','Ssurf',&
          'Tref ','old  ','new  ','Us   ','Vs   ','Ts   ','Ss   ','hmixd'/)
 
+  CHARACTER(LEN=28) :: routine = "MCKPP_RESTART_IO_READ_NETCDF"
+  CHARACTER(LEN=max_message_len) :: message
+
 #ifdef MCKPP_CAM3
   IF (masterproc) THEN
 
@@ -727,33 +745,37 @@ SUBROUTINE MCKPP_RESTART_IO_READ_NETCDF()
   ALLOCATE( temp_twod(my_nx*my_ny,1:NZP1) )
      
   netcdf_restart_infile = TRIM(ADJUSTL(kpp_const_fields%restart_infile)) // '.nc'
-  WRITE(nuout,*) netcdf_restart_infile
-
   status=NF_OPEN(netcdf_restart_infile,NF_NOWRITE,ncid)
   
   ! Conduct safety checks on the restart file for number of longitudes, latitudes and vertical points
   status=NF_INQ_DIMID(ncid,'longitude',dimids(1))
   status=NF_INQ_DIMLEN(ncid,dimids(1),file_nlon)
   IF (file_nlon .NE. my_nx) THEN
-     WRITE(nuerr,*) 'MCKPP_RESTART_IO_READ_NETCDF: Number of longitudes in restart file is ',file_nlon,&
-          ' but number of longitudes in the model is ',my_nx,'.  &
-          & Please correct either the restart file or the model in order to continue.'
-  !   CALL MCKPP_ABORT()
+     WRITE(message,*) 'Number of longitudes in restart file is ', file_nlon, &
+          ' but number of longitudes in the model is ' ,my_nx
+     CALL mckpp_print_error(routine, message) 
+     WRITE(message,*) 'Please correct either the restart file or the model in order to continue.'
+     CALL mckpp_print_error(routine, message) 
+     ! CALL MCKPP_ABORT()
   ENDIF
   status=NF_INQ_DIMID(ncid,'latitude',dimids(1))
   status=NF_INQ_DIMLEN(ncid,dimids(1),file_nlat)
   IF (file_nlat .NE. my_ny) THEN
-     WRITE(nuerr,*) 'MCKPP_RESTART_IO_READ_NETCDF: Number of latitudes in restart file is ',file_nlat,&
-          ' but number of latitudes in the model is ',my_ny,'.  &
-          & Please correct either the restart file or the model in order to continue.'
+     WRITE(message,*) 'Number of latitudes in restart file is ', file_nlat, &
+         ' but number of latitudes in the model is ', my_ny
+     CALL mckpp_print_error(routine, message) 
+     WRITE(message,*) 'Please correct either the restart file or the model in order to continue.'
+     CALL mckpp_print_error(routine, message) 
      CALL MCKPP_ABORT()
   ENDIF
   status=NF_INQ_DIMID(ncid,'z',dimids(1))
   status=NF_INQ_DIMLEN(ncid,dimids(1),file_nz)
   IF (file_nz .NE. NZP1) THEN
-     WRITE(nuerr,*) 'MCKPP_RESTART_IO_READ_NETCDF: Number of depths in restart file is ',file_nz,&
-          ' but number of depths in the model is ',NZP1,'.  &
-          & Please correct either the restart file or the model in order to continue.'
+     WRITE(message,*) 'Number of depths in restart file is ', file_nz, &
+         ' but number of depths in the model is ', NZP1
+     CALL mckpp_print_error(routine, message) 
+     WRITE(message,*) 'Please correct either the restart file or the model in order to continue.'
+     CALL mckpp_print_error(routine, message) 
      CALL MCKPP_ABORT()
   ENDIF
 
@@ -784,9 +806,12 @@ DO ivar=1,nvars
       IF (masterproc) THEN
 #endif
       IF (ABS(kpp_const_fields%time-kpp_const_fields%startt) .GT. 1e-4) THEN
-         WRITE(nuerr,*) 'MCKPP_RESTART_IO_READ_NETCDF: Start time does not match the restart record.'
-         WRITE(nuerr,*) 'MCKPP_RESTART_IO_READ_NETCDF: Start time in restart record = ',kpp_const_fields%time
-         WRITE(nuerr,*) 'MCKPP_RESTART_IO_READ_NETCDF: Start time in namelist = ',kpp_const_fields%startt
+         WRITE(message,*) 'Start time does not match the restart record.'
+         CALL mckpp_print_error(routine, message) 
+         WRITE(message,*) 'Start time in restart record = ',kpp_const_fields%time
+         CALL mckpp_print_error(routine, message) 
+         WRITE(message,*) 'Start time in namelist = ',kpp_const_fields%startt
+         CALL mckpp_print_error(routine, message) 
          ! CALL MCKPP_ABORT
       ENDIF
 #ifdef MCKPP_CAM3

--- a/mc-kpp_restart_io.F90
+++ b/mc-kpp_restart_io.F90
@@ -2,7 +2,7 @@
 SUBROUTINE MCKPP_RESTART_IO_READ()
 
   USE mckpp_data_fields, ONLY: kpp_3d_fields,kpp_const_fields
-  USE mckpp_log_messages, ONLY: mckpp_print, max_message_len
+  USE mckpp_log_messages, ONLY: mckpp_print, mckpp_print_error, max_message_len
   USE mckpp_parameters, ONLY: npts, nzp1
   
   IMPLICIT NONE

--- a/mc-kpp_timer.F90
+++ b/mc-kpp_timer.F90
@@ -1,10 +1,11 @@
 MODULE mckpp_timer
 
-  USE mckpp_parameters, ONLY: nuout, nuerr, max_error_msg_len
+  USE mckpp_log_messages, ONLY: mckpp_print, mckpp_print_error, max_message_len
   
   IMPLICIT NONE 
 
-  PUBLIC :: mckpp_initialize_timers, mckpp_start_timer, mckpp_stop_timer, mckpp_print_timers, mckpp_define_new_timer
+  PUBLIC :: mckpp_initialize_timers, mckpp_start_timer, mckpp_stop_timer, &
+      mckpp_print_timers, mckpp_define_new_timer
 
   PRIVATE
 
@@ -22,6 +23,8 @@ MODULE mckpp_timer
 
   INTEGER :: timers_allocated, index_timer, index_total
 
+  CHARACTER(LEN=11) :: routine = "MCKPP_TIMER"
+  CHARACTER(LEN=max_message_len) :: message
 
 CONTAINS 
 
@@ -71,8 +74,9 @@ CONTAINS
     END IF 
 
     IF (index .NE. -1) THEN     
-      IF (timers(index)%running .EQV. .TRUE.) THEN       
-        WRITE(nuerr,*) 'KPP TIMER : Trying to start timer ', name, ' when it is already running.'
+      IF (timers(index)%running .EQV. .TRUE.) THEN
+        WRITE(message,*) "Trying to start timer ", TRIM(name), " when it is already running."
+        CALL mckpp_print_error(routine, message) 
       ELSE 
         timers(index)%start_time = get_current_time()
         timers(index)%running = .TRUE.
@@ -91,16 +95,16 @@ CONTAINS
   
     REAL(kind=8) time
     INTEGER :: index 
-    CHARACTER(LEN=max_error_msg_len) :: error_msg
-
+ 
     time = get_current_time()
 
-    index = lookup_timer_index(name) 
-    error_msg = 'KPP TIMER : Trying to stop timer '//name//' when it is not running.'
+    index = lookup_timer_index(name)
+    WRITE(message,*) "Trying to stop timer ", TRIM(name), " when it is not running."
+    
     IF (index .EQ. -1) THEN  
-      WRITE(nuerr,*) error_msg
+      CALL mckpp_print_error(routine, message) 
     ELSE IF (timers(index)%running .EQV. .FALSE.) THEN 
-      WRITE(nuerr,*) error_msg
+      CALL mckpp_print_error(routine, message) 
     ELSE 
       timers(index)%elapsed_time = timers(index)%elapsed_time + & 
                                    (time - timers(index)%start_time) 
@@ -109,7 +113,6 @@ CONTAINS
 
     timers(index_timer)%elapsed_time = timers(index_timer)%elapsed_time + & 
                                       (get_current_time() - time) 
-
   END SUBROUTINE mckpp_stop_timer
 
   
@@ -123,10 +126,12 @@ CONTAINS
     timers(index_total)%elapsed_time = time - timers(index_total)%start_time
 
     ! Print statistics 
-    WRITE(nuout,*) '**** KPP TIMER STATISTICS ****'
-    WRITE(nuout,'(A10,20X,2X,A22)') 'Timer name', 'Elapsed_time(s)' 
+    CALL mckpp_print(routine, "**** KPP TIMER STATISTICS ****")
+    WRITE(message,'(A10,20X,2X,A22)') 'Timer name', 'Elapsed_time(s)' 
+    CALL mckpp_print("", message) 
     DO i = 1, timers_allocated
-      WRITE(nuout,'(A30,2X,F11.3)') timers(i)%name, timers(i)%elapsed_time
+      WRITE(message,'(A30,2X,F11.3)') timers(i)%name, timers(i)%elapsed_time
+      CALL mckpp_print("", message)     
     END DO 
 
   END SUBROUTINE mckpp_print_timers 
@@ -139,7 +144,7 @@ CONTAINS
 
     index = -1 
     IF (timers_allocated .GE. max_timers) THEN 
-      WRITE(nuerr,*) 'KPP TIMER : Reached maximum number of timers'
+      CALL mckpp_print_error(routine, "Reached maximum number of timers") 
       RETURN
     END IF 
 
@@ -158,8 +163,9 @@ CONTAINS
     lookup_timer_index = -1
 
     ! Check length of timer name
-    IF (LEN(name) .GT. max_name_length) THEN 
-      WRITE(nuerr,*) 'KPP TIMER : Name of timer must not exceed ', max_name_length, ' characters: ', name
+    IF (LEN(name) .GT. max_name_length) THEN
+      WRITE(message,*) 'KPP TIMER : Name of timer must not exceed ', max_name_length, ' characters: ', name
+      CALL mckpp_print_error(routine, message)
       RETURN
     ENDIF
    

--- a/mc-kpp_timer.F90
+++ b/mc-kpp_timer.F90
@@ -164,7 +164,7 @@ CONTAINS
 
     ! Check length of timer name
     IF (LEN(name) .GT. max_name_length) THEN
-      WRITE(message,*) 'KPP TIMER : Name of timer must not exceed ', max_name_length, ' characters: ', name
+      WRITE(message,*) 'Name of timer must not exceed ', max_name_length, ' characters: ', name
       CALL mckpp_print_error(routine, message)
       RETURN
     ENDIF

--- a/mc-kpp_xios_control.F90
+++ b/mc-kpp_xios_control.F90
@@ -2,7 +2,7 @@
 MODULE mckpp_xios_control
 
   USE mckpp_data_fields, ONLY: kpp_3d_fields,kpp_const_fields
-  USE mckpp_parameters, ONLY: nuout
+  USE mckpp_log_messages, ONLY: mckpp_print, max_message_len
   USE mckpp_timer, ONLY: mckpp_start_timer, mckpp_stop_timer
   USE mckpp_xios_io, ONLY: xios_comm, ctx_hdl_diags, &
       mckpp_xios_diagnostic_definition, mckpp_xios_diagnostic_output, &
@@ -52,6 +52,8 @@ CONTAINS
   SUBROUTINE mckpp_restart_control() 
 
     REAL :: restart_time
+    CHARACTER(LEN=21) :: routine = "MCKPP_RESTART_CONTROL"
+    CHARACTER(LEN=max_message_len) :: message
 
     ! Check if restart timestep 
     ! - always write restart at end of run 
@@ -63,7 +65,8 @@ CONTAINS
       ! (end of this timestep = start of next timestep)
       restart_time=kpp_const_fields%time+kpp_const_fields%dto/kpp_const_fields%spd
 
-      WRITE(nuout,*) "Writing restart at time ", restart_time    
+      WRITE(message,*) "Writing restart at time ", restart_time
+      CALL mckpp_print(routine, message)
       CALL mckpp_xios_write_restart(restart_time) 
     END IF
     CALL mckpp_stop_timer("Write restart output") 


### PR DESCRIPTION
Replace all write statements to stdout and stderr with calls to logging subroutines. This is to support MPI parallelism, as control of which task print messages can be done from within the print logging module. It also simplifies the CAM interface, which otherwise has an if-test for masterproc at every write statement. 