### PR TITLE
Time control

### DIFF
--- a/Makefile.linux_gfortran-local
+++ b/Makefile.linux_gfortran-local
@@ -49,7 +49,7 @@ EXECUTABLE=KPP_ocean
 
 FORCED_FILES = $(wildcard *.F90)
 FORCED_OBJS = $(FORCED_FILES:.F90=.o)
-FORCED_MODS = mckpp_log_messages.mod mckpp_parameters.mod mckpp_timer.mod mckpp_data_fields.mod mckpp_namelists.mod mckpp_xios_control.mod mckpp_xios_io.mod
+FORCED_MODS = mckpp_log_messages.mod mckpp_parameters.mod mckpp_timer.mod mckpp_data_fields.mod mckpp_namelists.mod mckpp_xios_control.mod mckpp_xios_io.mod mckpp_time_control.mod
 
 FORCED_COMPILE = $(F90) $(F90_FLAGS) $(CPP_FLAGS) $(F90_CPP_FLAG)-DARCHER $(OASIS3_MOD_FLAG) $(XIOS_INC) $(NCDF_INC) 
 FORCED_LINK = $(F90)  $(F90_FLAGS) $(LINK_FLAGS) $(FORCED_OBJS) -o ${EXECUTABLE} ${XIOS_LIB} ${NCDF_LIB}
@@ -79,6 +79,9 @@ mckpp_xios_io.mod : mc-kpp_xios_io.F90 mckpp_timer.mod mckpp_parameters.mod mckp
 	$(FORCED_COMPILE) -c $<
 
 mckpp_xios_control.mod : mc-kpp_xios_control.F90 mckpp_timer.mod mckpp_xios_io.mod mckpp_data_fields.mod
+	$(FORCED_COMPILE) -c $<
+
+mckpp_time_control.mod : mc-kpp_time_control.F90 mckpp_data_fields.mod
 	$(FORCED_COMPILE) -c $<
 
 forced : CPP_FLAGS=$(F90_CPP_FLAG)-DOPENMP

--- a/mc-kpp_data_fields.F90
+++ b/mc-kpp_data_fields.F90
@@ -232,7 +232,8 @@ MODULE mckpp_data_fields
         nstart, & 
         nend, & 
         ndtocn, & 
-        ntime, & 
+        ntime, &
+        num_timesteps, & 
         iso_bot, & 
         dt_uvdamp, & 
         ndt_per_restart, & 

--- a/mc-kpp_initialize_namelists.F90
+++ b/mc-kpp_initialize_namelists.F90
@@ -161,6 +161,7 @@ SUBROUTINE MCKPP_INITIALIZE_NAMELIST()
   
   ! Initialize and read the landsea name list
   L_LANDSEA=.FALSE.
+  landsea_file = ''
   READ(75,NAME_LANDSEA)
   CALL mckpp_print(routine, "Read Namelist LANDSEA")
   
@@ -168,9 +169,11 @@ SUBROUTINE MCKPP_INITIALIZE_NAMELIST()
   L_INITDATA= .TRUE.
   L_INTERPINIT= .TRUE.
   L_RESTART= .FALSE.
+  initdata_file = ''
   WRITE(restart_infile,*) 'fort.30'
   READ(75,NAME_START) 
   CALL mckpp_print(routine, "Read Namelist START")
+  WRITE(6,*) "Init file = ", initdata_file
   
   ! Initialize and read the times namelist
   ndtocn=1
@@ -190,7 +193,8 @@ SUBROUTINE MCKPP_INITIALIZE_NAMELIST()
   kpp_const_fields%dto=kpp_const_fields%dtsec/float(kpp_const_fields%ndtocn)
   kpp_const_fields%nend=int((kpp_const_fields%finalt-kpp_const_fields%startt)/kpp_const_fields%dtsec)
   kpp_const_fields%nstart=nint(kpp_const_fields%startt)/kpp_const_fields%dto
-  IF (float(kpp_const_fields%nend*kpp_const_fields%ndtocn) .NE. &
+  kpp_const_fields%num_timesteps=kpp_const_fields%nend*kpp_const_fields%ndtocn
+  IF (float(kpp_const_fields%num_timesteps) .NE. &
        (kpp_const_fields%finalt-kpp_const_fields%startt)/kpp_const_fields%dto) THEN
      CALL mckpp_print_error(routine, "The integration length is not a multiple of the ocean timestep")
      WRITE(message, *) "dto = ", kpp_const_fields%dto, ", finalt = ", kpp_const_fields%finalt, &

--- a/mc-kpp_initialize_namelists.F90
+++ b/mc-kpp_initialize_namelists.F90
@@ -161,7 +161,6 @@ SUBROUTINE MCKPP_INITIALIZE_NAMELIST()
   
   ! Initialize and read the landsea name list
   L_LANDSEA=.FALSE.
-  landsea_file = ''
   READ(75,NAME_LANDSEA)
   CALL mckpp_print(routine, "Read Namelist LANDSEA")
   
@@ -169,11 +168,9 @@ SUBROUTINE MCKPP_INITIALIZE_NAMELIST()
   L_INITDATA= .TRUE.
   L_INTERPINIT= .TRUE.
   L_RESTART= .FALSE.
-  initdata_file = ''
   WRITE(restart_infile,*) 'fort.30'
   READ(75,NAME_START) 
   CALL mckpp_print(routine, "Read Namelist START")
-  WRITE(6,*) "Init file = ", initdata_file
   
   ! Initialize and read the times namelist
   ndtocn=1

--- a/mc-kpp_netcdf_subs.F90
+++ b/mc-kpp_netcdf_subs.F90
@@ -307,7 +307,7 @@ SUBROUTINE MCKPP_READ_IPAR (ncid,vname,npars,nt,par_out)
 END SUBROUTINE MCKPP_READ_IPAR
 
 SUBROUTINE MCKPP_DETERMINE_NETCDF_BOUNDARIES(ncid,file_description,latitude_name,longitude_name,&
-     time_name,start_lon,start_lat,offset_lon,offset_lat,first_time,last_time,time_varid)
+     time_name,start_lon,start_lat,offset_lon,offset_lat,first_time,last_time,time_varid,ntime_file)
 
   USE mckpp_log_messages, ONLY: mckpp_print_error, max_message_len
   USE mckpp_parameters, ONLY: nx_globe, ny_globe
@@ -317,11 +317,12 @@ SUBROUTINE MCKPP_DETERMINE_NETCDF_BOUNDARIES(ncid,file_description,latitude_name
 #include <netcdf.inc>
 
   INTEGER ncid,offset_lon,offset_lat,lon_dimid,lon_varid,lat_dimid,lat_varid,time_dimid,time_varid,ix,iy
-  REAL start_lon,start_lat,first_time,last_time      
+  REAL start_lon,start_lat,first_time,last_time
+  INTEGER, OPTIONAL :: ntime_file
   CHARACTER(*) file_description,latitude_name,longitude_name,time_name
   CHARACTER(LEN=30) tmp_name
   
-  INTEGER nlat_file,nlon_file,ntime_file,status
+  INTEGER nlat_file,nlon_file,status
   REAL*4 longitudes(NX_GLOBE),latitudes(NY_GLOBE)
 
   CHARACTER(LEN=33) :: routine = "MCKPP_DETERMINE_NETCDF_BOUNDARIES"

--- a/mc-kpp_ocean_model_3D.F90
+++ b/mc-kpp_ocean_model_3D.F90
@@ -28,7 +28,8 @@ IMPLICIT NONE
   ! Main time-stepping loop
   CALL mckpp_print(routine, "Timestepping loop")
 
-  DO ntime = 1, kpp_const_fields%nend*kpp_const_fields%ndtocn
+  DO ntime = 1, kpp_const_fields%num_timesteps
+
      kpp_const_fields%ntime = ntime
      kpp_const_fields%time = kpp_const_fields%startt+(kpp_const_fields%ntime-1)*&
        kpp_const_fields%dto/kpp_const_fields%spd

--- a/mc-kpp_ocean_model_3D.F90
+++ b/mc-kpp_ocean_model_3D.F90
@@ -1,18 +1,19 @@
 PROGRAM mckpp_ocean_model_3d
 
-USE mckpp_data_fields, ONLY: kpp_3d_fields, kpp_const_fields
-USE mckpp_log_messages, ONLY: mckpp_print, max_message_len
-USE mckpp_timer, ONLY: mckpp_initialize_timers, mckpp_start_timer, &
-    mckpp_stop_timer, mckpp_print_timers
-USE mckpp_xios_control, ONLY: mckpp_initialize_output, mckpp_output_control, &
-    mckpp_restart_control, mckpp_finalize_output
+  USE mckpp_data_fields, ONLY: kpp_3d_fields, kpp_const_fields
+  USE mckpp_log_messages, ONLY: mckpp_print, max_message_len
+  USE mckpp_time_control, ONLY: mckpp_update_time
+  USE mckpp_timer, ONLY: mckpp_initialize_timers, mckpp_start_timer, &
+      mckpp_stop_timer, mckpp_print_timers
+  USE mckpp_xios_control, ONLY: mckpp_initialize_output, mckpp_output_control, &
+      mckpp_restart_control, mckpp_finalize_output
 
-IMPLICIT NONE
+  IMPLICIT NONE
 
   INTEGER :: ntime
   CHARACTER(LEN=20) :: routine = "MCKPP_OCEAN_MODEL_3D"
   CHARACTER(LEN=max_message_len) :: message
-  
+
   ! Initialise
   CALL mckpp_print(routine, "Initialisation")
 
@@ -30,39 +31,38 @@ IMPLICIT NONE
 
   DO ntime = 1, kpp_const_fields%num_timesteps
 
-     kpp_const_fields%ntime = ntime
-     kpp_const_fields%time = kpp_const_fields%startt+(kpp_const_fields%ntime-1)*&
-       kpp_const_fields%dto/kpp_const_fields%spd
-     WRITE(message,*) "ntime, time = ", kpp_const_fields%ntime, kpp_const_fields%time
-     CALL mckpp_print(routine, message)
+    ! Update time variables
+    CALL mckpp_update_time(ntime) 
+    WRITE(message,*) "ntime, time = ", kpp_const_fields%ntime, kpp_const_fields%time
+    CALL mckpp_print(routine, message)
 
-     ! Fluxes
-     IF (MOD(kpp_const_fields%ntime-1,kpp_const_fields%ndtocn) .EQ. 0) THEN
-       CALL mckpp_start_timer("Update surface fluxes")
-       CALL mckpp_fluxes()
-       CALL mckpp_stop_timer("Update surface fluxes")
-     ENDIF
+    ! Fluxes
+    IF (MOD(kpp_const_fields%ntime-1,kpp_const_fields%ndtocn) .EQ. 0) THEN
+      CALL mckpp_start_timer("Update surface fluxes")
+      CALL mckpp_fluxes()
+      CALL mckpp_stop_timer("Update surface fluxes")
+    ENDIF
 
-     ! Update boundary conditions
-     IF (kpp_const_fields%ntime .ne. 1) THEN 
-       CALL mckpp_start_timer("Update ancillaries")
-       CALL mckpp_boundary_update()
-       CALL mckpp_stop_timer("Update ancillaries")
-     ENDIF 
-       
-     ! Physics
-     CALL mckpp_physics_driver()
+    ! Update boundary conditions
+    IF (kpp_const_fields%ntime .ne. 1) THEN 
+      CALL mckpp_start_timer("Update ancillaries")
+      CALL mckpp_boundary_update()
+      CALL mckpp_stop_timer("Update ancillaries")
+    ENDIF
 
-     ! Diagnostic output 
-     CALL mckpp_start_timer("Diagnostic output") 
-     CALL mckpp_output_control()
-     CALL mckpp_stop_timer("Diagnostic output")
+    ! Physics
+    CALL mckpp_physics_driver()
 
-     ! Restart output
-     CALL mckpp_start_timer("Restart output")     
-     CALL mckpp_restart_control()
-     CALL mckpp_stop_timer("Restart output")
-     
+    ! Diagnostic output 
+    CALL mckpp_start_timer("Diagnostic output") 
+    CALL mckpp_output_control()
+    CALL mckpp_stop_timer("Diagnostic output")
+
+    ! Restart output
+    CALL mckpp_start_timer("Restart output")     
+    CALL mckpp_restart_control()
+    CALL mckpp_stop_timer("Restart output")
+
   END DO
 
   ! Finalise

--- a/mc-kpp_time_control.F90
+++ b/mc-kpp_time_control.F90
@@ -4,7 +4,8 @@ MODULE mckpp_time_control
   ! deriving validity times for I/O routines.
   ! Time variables all stored in kpp_const_fields 
 
-USE mckpp_data_fields, ONLY: kpp_const_fields
+  USE mckpp_data_fields, ONLY: kpp_const_fields
+  USE mckpp_log_messages, ONLY: mckpp_print, mckpp_print_error, max_message_len
   
 IMPLICIT NONE
 
@@ -31,7 +32,62 @@ CONTAINS
     mckpp_get_time = kpp_const_fields%startt + (ntime-1) * &
        kpp_const_fields%dto / kpp_const_fields%spd
   
-  END FUNCTION mckpp_get_time  
+  END FUNCTION mckpp_get_time
+
+
+  ! Work out time for ancil data reads, based on current model time, udpate freq,
+  ! and time dim from file. 
+  ! Return time to read in, and position in time dimension in file. 
+  SUBROUTINE mckpp_get_update_time(file, time, nupdate, file_times, num_times, periodic, period, &
+      update_time, update_time_pos)
+
+    CHARACTER(LEN=*) :: file
+    REAL, INTENT(IN) :: time 
+    INTEGER, INTENT(IN) :: nupdate, num_times, period
+    REAL*4, DIMENSION(num_times), INTENT(IN) :: file_times
+    LOGICAL, INTENT(IN) :: periodic
+    REAL*4, INTENT(OUT) :: update_time
+    INTEGER, INTENT(OUT) :: update_time_pos
+
+    REAL :: first_file_time, last_file_time, file_update_time
+    CHARACTER(LEN=21) :: routine = "MCKPP_GET_UPDATE_TIME"
+    CHARACTER(LEN=max_message_len) :: message
+
+    first_file_time = file_times(1)
+    last_file_time = file_times(num_times)
+
+    update_time = time + 0.5 * (kpp_const_fields%dto / kpp_const_fields%spd) * nupdate
+    update_time_pos = NINT( (update_time-first_file_time)*kpp_const_fields%spd / &
+        (kpp_const_fields%dto*nupdate) ) + 1
+
+    ! Check if ancil is periodic 
+    IF (update_time .GT. last_file_time) THEN
+      IF (periodic) THEN
+         DO WHILE (update_time .GT. last_file_time) 
+           update_time = update_time - period
+        END DO
+      ELSE
+        WRITE(message,*) "Time to read exceeds the last time in the netCDF file", &
+            " and periodic reads have not been specified."
+        CALL mckpp_print_error(routine, message)
+        WRITE(message,*) update_time, TRIM(file)
+        CALL mckpp_print_error(routine, message)
+        CALL mckpp_abort()
+      END IF
+    END IF
+    
+    ! Check this matches time entry in file 
+    file_update_time = file_times(update_time_pos)
+    IF ( ABS(file_update_time - update_time) .GT. & 
+        (0.01 * kpp_const_fields%dtsec / kpp_const_fields%spd) ) THEN
+      WRITE(message,*) 'Cannot find time,', update_time, 'in ', TRIM(file)
+      CALL mckpp_print_error(routine, message) 
+      WRITE(message,*) 'The closest I came was', file_update_time
+      CALL mckpp_print_error(routine, message) 
+      CALL mckpp_abort()
+    END IF
+
+  END SUBROUTINE mckpp_get_update_time 
 
 
 END MODULE mckpp_time_control

--- a/mc-kpp_time_control.F90
+++ b/mc-kpp_time_control.F90
@@ -1,0 +1,37 @@
+MODULE mckpp_time_control
+
+  ! Routines to work with timestep counter, current time, and
+  ! deriving validity times for I/O routines.
+  ! Time variables all stored in kpp_const_fields 
+
+USE mckpp_data_fields, ONLY: kpp_const_fields
+  
+IMPLICIT NONE
+
+PUBLIC
+  
+CONTAINS
+
+  ! Update ntime and time in kpp_const_fields
+  SUBROUTINE mckpp_update_time(ntime)
+
+    INTEGER, INTENT(IN) :: ntime ! new timestep
+
+    kpp_const_fields%ntime = ntime
+    kpp_const_fields%time = mckpp_get_time(ntime)
+
+  END SUBROUTINE mckpp_update_time
+  
+
+  ! Return time for a given timestep
+  REAL FUNCTION mckpp_get_time(ntime)
+
+    INTEGER, INTENT(IN) :: ntime ! timestep
+
+    mckpp_get_time = kpp_const_fields%startt + (ntime-1) * &
+       kpp_const_fields%dto / kpp_const_fields%spd
+  
+  END FUNCTION mckpp_get_time  
+
+
+END MODULE mckpp_time_control

--- a/mc-kpp_xios_control.F90
+++ b/mc-kpp_xios_control.F90
@@ -58,8 +58,8 @@ CONTAINS
     ! Check if restart timestep 
     ! - always write restart at end of run 
     CALL mckpp_start_timer("Write restart output") 
-    IF (MOD(kpp_const_fields%ntime,kpp_const_fields%ndt_per_restart) .EQ. 0 .OR. &
-        kpp_const_fields%ntime .EQ. kpp_const_fields%nend*kpp_const_fields%ndtocn) THEN
+    IF (MOD(kpp_const_fields%ntime, kpp_const_fields%ndt_per_restart) .EQ. 0 .OR. &
+        kpp_const_fields%ntime .EQ. kpp_const_fields%num_timesteps) THEN
 
       ! Set correct time for validity of restart file
       ! (end of this timestep = start of next timestep)

--- a/mc-kpp_xios_control.F90
+++ b/mc-kpp_xios_control.F90
@@ -3,6 +3,7 @@ MODULE mckpp_xios_control
 
   USE mckpp_data_fields, ONLY: kpp_3d_fields,kpp_const_fields
   USE mckpp_log_messages, ONLY: mckpp_print, max_message_len
+  USE mckpp_time_control, ONLY: mckpp_get_time
   USE mckpp_timer, ONLY: mckpp_start_timer, mckpp_stop_timer
   USE mckpp_xios_io, ONLY: xios_comm, ctx_hdl_diags, &
       mckpp_xios_diagnostic_definition, mckpp_xios_diagnostic_output, &
@@ -63,7 +64,7 @@ CONTAINS
 
       ! Set correct time for validity of restart file
       ! (end of this timestep = start of next timestep)
-      restart_time=kpp_const_fields%time+kpp_const_fields%dto/kpp_const_fields%spd
+      restart_time = mckpp_get_time(kpp_const_fields%ntime+1)
 
       WRITE(message,*) "Writing restart at time ", restart_time
       CALL mckpp_print(routine, message)


### PR DESCRIPTION
Adds a new constant num_timesteps. 
Adds a module to hold routines that work with model time. 
* Update model time based on timestep increment 
* Work out time to read from ancillary file, based on update frequency etc. 

The contents of these routines is based entirely on existing code, so should produce no change in functionality. 

Note that I have not updated all the ancil read routines to use the new module, but will do so in netcdf branch whilst rewriting these routines. 